### PR TITLE
Bump bayesian-workflow skill to v1.1

### DIFF
--- a/bayesian-workflow/SKILL.md
+++ b/bayesian-workflow/SKILL.md
@@ -14,7 +14,7 @@ description: >
 license: MIT
 metadata:
   author: [Alexandre Andorra](https://alexandorra.github.io/)
-  version: "1.0"
+  version: "1.1"
 ---
 
 # Bayesian Workflow
@@ -94,14 +94,31 @@ with pm.Model(coords=coords) as model:
 - **Use ArviZ for all plots and calibration.** Don't write custom plotting code when ArviZ already handles it — including for binary data, count data, and calibration. ArviZ developers have thought through edge cases so you don't have to.
 - **Prefer xarray over numpy for InferenceData operations.** `InferenceData` and `DataTree` objects are backed by xarray — use xarray's labeled indexing (`.sel()`, `.mean(dim=...)`, etc.) instead of converting to numpy arrays. This preserves dimension labels, avoids shape bugs, and makes code more readable. Fall back to numpy only when xarray can't do what you need.
 - **Always generate analysis notes alongside code.** When producing a model script, also produce a companion markdown file (`analysis_notes.md` or similar) that interprets the results — what the diagnostics mean, what the posteriors tell us, what the calibration plots show. Code without interpretation is incomplete.
+- **Always use the posterior mean (not median) for predictive probabilities.** The proper Bayesian predictive distribution averages over the posterior: `P(Y=k|x) = (1/S) Σ P(Y=k|x,θₛ)`. This is the mean, not the median. The median does not correspond to the posterior predictive distribution, can violate probability coherence (probabilities may not sum to 1), and biases calibration due to Jensen's inequality. In code: use `np.mean(probs, axis=sample_axis)`, never `np.median(...)`.
+- **Use `pm.set_data()` + `pm.sample_posterior_predictive()` for out-of-sample predictions.** Don't manually extract posterior samples and recompute predictions — let PyMC propagate uncertainty properly. Define predictors as `pm.Data(...)` during model building, then swap in new data:
+
+```python
+# After fitting the model:
+with model:
+    pm.set_data({"X": X_new, "group_idx": group_idx_new})
+    oos_preds = pm.sample_posterior_predictive(idata, predictions=True, random_seed=rng)
+```
+
+- **Check model identifiability before interpreting components.** If two model components always appear together in the likelihood (e.g., a league intercept and a home advantage term when every observation is from home perspective), their individual posteriors reflect prior assumptions, not data signal — only their sum is identified. Use `az.plot_pair()` to check for strong posterior correlations between components. If correlation is near ±1, the components are not separately identifiable — either merge them or restructure the data.
 
 ## Common model families
 
 | Problem | Likelihood | Typical priors | Reference |
 |---|---|---|---|
 | Continuous outcome | Normal / StudentT | Normal, Gamma avoiding 0 for positive-constrained parameters | [references/priors.md](references/priors.md) |
-| Binary outcome | Bernoulli or Binomial if aggregted, with logit inverse-link | Normal(0, 1.5) on coeffs | [references/priors.md](references/priors.md) |
+| Binary outcome | Bernoulli or Binomial if aggregated, with logit inverse-link | Normal(0, 1.5) on coeffs | [references/priors.md](references/priors.md) |
 | Count data | Poisson / NegBinomial | Gamma on rate, avoiding 0 | [references/priors.md](references/priors.md) |
+| Count data with excess zeros | ZeroInflatedPoisson / ZeroInflatedNegBinomial | Gamma on rate; Beta or Normal+logit on zero-inflation prob | [references/priors.md](references/priors.md) |
+| Positive count data (no zeros) | Hurdle Poisson / Hurdle NegBinomial | Separate zero-gate (Bernoulli) and count (Truncated) components | [references/priors.md](references/priors.md) |
+| Ordinal outcome | OrderedLogistic (cumulative link) | Normal on coeffs; Normal with ordered transform on cutpoints | [references/priors.md](references/priors.md) |
+| Censored data (survival, limits of detection) | `pm.Censored(dist, lower, upper)` | Same as uncensored, applied to underlying distribution | [references/priors.md](references/priors.md) |
+| Truncated data | `pm.Truncated(dist, lower, upper)` | Same as underlying distribution | [references/priors.md](references/priors.md) |
+| High-dimensional / sparse regression | Normal / StudentT with sparsity prior on coefficients | Regularized Horseshoe or R2-D2 on coeffs | [references/priors.md](references/priors.md) |
 | Hierarchical / multilevel | Varies | See partial pooling pattern | [references/hierarchical.md](references/hierarchical.md) |
 | Time series | state space models / Gaussian Processes | Problem-specific | [references/priors.md](references/priors.md) |
 
@@ -130,6 +147,8 @@ These are battle-tested lessons that save hours of debugging:
 - **Flat priors on scale parameters** (`HalfCauchy`, `HalfFlat`) cause funnels in hierarchical models. Use `Gamma(2, ...)` or `Exponential` — these avoid the near-zero region that creates sampling problems. If there's no group-level variation to detect, you don't need the hierarchy.
 - **Python conditionals in models** (`if x > 0`) don't work inside PyMC. Use `pm.math.switch` or `pytensor.tensor.where` instead.
 - **Forgetting to standardize predictors** makes shared priors inappropriate and slows sampling. Always standardize before fitting, then back-transform for interpretation.
+- **Horseshoe priors create a double-funnel geometry** that standard NUTS can struggle with. Always use the **regularized (Finnish) horseshoe** (Piironen & Vehtari, 2017), which adds a slab component that smooths the geometry. Set `target_accept=0.95` or higher. If you see divergences with a horseshoe model, this is almost certainly the cause.
+- **`np.median` on posterior predictive probabilities is a silent bug.** It does not produce the Bayesian predictive distribution and can yield probabilities that don't sum to 1 across categories. Always use `np.mean` over the posterior samples dimension.
 
 ## When things go wrong
 
@@ -142,3 +161,4 @@ These are battle-tested lessons that save hours of debugging:
 | Post. pred. misses data | Model misspecification | Add complexity (varying slopes, different likelihood, interaction terms) |
 | `log_likelihood` missing | nutpie doesn't auto-store it | Call `pm.compute_log_likelihood(idata, model=model)` after sampling |
 | Slow model | Large Deterministics or recompilation | Profile with `model.profile(model.logp())`, avoid large `Deterministic` arrays |
+| Slow to initialize / poor warmup | Bad starting point | Try `init="adapt_diag_grad"` in `pm.sample()`, or run `pymc_extras.fit_pathfinder()` first and pass its MAP estimates as `initvals` |

--- a/bayesian-workflow/SKILL.md
+++ b/bayesian-workflow/SKILL.md
@@ -161,4 +161,4 @@ These are battle-tested lessons that save hours of debugging:
 | Post. pred. misses data | Model misspecification | Add complexity (varying slopes, different likelihood, interaction terms) |
 | `log_likelihood` missing | nutpie doesn't auto-store it | Call `pm.compute_log_likelihood(idata, model=model)` after sampling |
 | Slow model | Large Deterministics or recompilation | Profile with `model.profile(model.logp())`, avoid large `Deterministic` arrays |
-| Slow to initialize / poor warmup | Bad starting point | Try `init="adapt_diag_grad"` in `pm.sample()`, or run `pymc_extras.fit_pathfinder()` first and pass its MAP estimates as `initvals` |
+| Slow to initialize / poor warmup | Bad starting point | Try `init="adapt_diag_grad"` in `pm.sample()`, or run `pmx.fit(method="pathfinder")` first (`import pymc_extras as pmx`) and pass its estimates as `initvals` |

--- a/bayesian-workflow/references/hierarchical.md
+++ b/bayesian-workflow/references/hierarchical.md
@@ -144,3 +144,36 @@ plt.ylabel("Posterior group mean")
 plt.legend()
 plt.title("Shrinkage toward global mean")
 ```
+
+---
+
+## Identifiability checks
+
+A model component is **identifiable** only if the data can distinguish its effect from other components. In hierarchical models, identifiability failures are common and subtle — the model samples fine, diagnostics pass, but individual component posteriors reflect prior assumptions, not data signal.
+
+### Common identifiability traps
+
+1. **Separate intercept + offset when the offset is always active**: If every observation has a characteristic (e.g., every match row is from the home team's perspective), you cannot separately estimate a "baseline" intercept and a "home advantage" offset — only their sum is identified. Merge them into a single intercept.
+
+2. **Overparameterized intercepts**: Group-level intercepts + a global intercept without a sum-to-zero constraint creates a "trading" pattern where the global intercept can shift arbitrarily as group intercepts compensate. Use `pm.ZeroSumNormal` for group intercepts or drop the global intercept.
+
+3. **Collinear covariates at the group level**: If a group-level predictor is nearly constant within groups (e.g., all teams in a league share the same league-level feature), it is confounded with the group intercept.
+
+### How to detect
+
+```python
+# Check posterior correlations between suspect components
+az.plot_pair(
+    idata,
+    var_names=["alpha", "delta"],
+    divergences=True,
+    marginals=True,
+)
+# If correlation is near ±1 → components are not separately identifiable
+```
+
+### What to do
+
+- **Merge confounded components** into a single term (honest about what the data can tell you)
+- **Add identifying variation** to the data (e.g., include away-team observations to separate home advantage from league baseline)
+- **Accept the constraint**: if you need both components for interpretability, acknowledge that their individual posteriors are prior-driven and report only their sum

--- a/bayesian-workflow/references/model-criticism.md
+++ b/bayesian-workflow/references/model-criticism.md
@@ -150,6 +150,106 @@ for j, name in enumerate(predictor_names):
 
 Look for: trends (missed nonlinearity), fans (heteroscedasticity), clusters (missing grouping variable).
 
+## Classification and ordinal model evaluation
+
+Standard PPC and calibration checks apply to classification models — **always run `plot_ppc_pit` first** (see Calibration assessment above). The metrics below supplement PPC-PIT with classification-specific numeric summaries. Note: `sklearn.metrics.brier_score_loss` exists but is binary-only; there is no standard package for multiclass ECE or categorical RPS, so we provide lightweight helpers:
+
+### Metrics for categorical/ordinal outcomes
+
+```python
+def expected_calibration_error(pred_probs, actuals, n_bins=10):
+    """Confidence-based ECE: are predicted probabilities well-calibrated?"""
+    # Standard ECE: bin on the model's confidence (max predicted probability),
+    # compare to accuracy within each bin.
+    confidences = np.max(pred_probs, axis=1)
+    predictions = np.argmax(pred_probs, axis=1)
+    accuracies = (predictions == actuals).astype(float)
+    bin_edges = np.linspace(0, 1, n_bins + 1)
+    ece = 0
+    for i in range(n_bins):
+        in_bin = (confidences >= bin_edges[i]) & (confidences < bin_edges[i + 1])
+        if in_bin.sum() > 0:
+            avg_confidence = confidences[in_bin].mean()
+            avg_accuracy = accuracies[in_bin].mean()
+            ece += np.abs(avg_confidence - avg_accuracy) * in_bin.sum()
+    return ece / len(actuals)
+
+def ranked_probability_score(pred_probs, actuals, n_classes):
+    """RPS: gold standard for ordinal outcomes. Penalizes being 'far off' more than Brier."""
+    rps = 0
+    for i, actual in enumerate(actuals):
+        pred_cum = np.cumsum(pred_probs[i])
+        actual_cum = np.zeros(n_classes)
+        actual_cum[int(actual):] = 1
+        rps += np.sum((pred_cum - actual_cum) ** 2)
+    return rps / len(actuals)
+```
+
+### Per-class calibration plots
+
+For classification models, always check calibration **per class**, not just overall. A model can be well-calibrated on average but poorly calibrated for specific outcomes (e.g., good at predicting home wins but overconfident on draws).
+
+```python
+fig, axes = plt.subplots(1, n_classes, figsize=(5 * n_classes, 4))
+for k, ax in enumerate(axes):
+    pred_k = pred_probs[:, k]
+    actual_k = (actuals == k).astype(float)
+    # Bin predictions and compute observed frequency
+    bin_edges = np.linspace(0, 1, 11)
+    bin_centers, bin_means = [], []
+    for i in range(10):
+        mask = (pred_k >= bin_edges[i]) & (pred_k < bin_edges[i + 1])
+        if mask.sum() > 5:
+            bin_centers.append(pred_k[mask].mean())
+            bin_means.append(actual_k[mask].mean())
+    ax.plot([0, 1], [0, 1], "k--", alpha=0.3)
+    ax.scatter(bin_centers, bin_means)
+    ax.set_title(f"Class {k}")
+    ax.set_xlabel("Predicted P")
+    ax.set_ylabel("Observed frequency")
+```
+
+### Key metrics summary
+
+| Metric | Use when | Interpretation |
+|--------|----------|---------------|
+| Brier score | Any categorical model | Lower is better. Random: ~0.67 (3-class) |
+| RPS | Ordinal outcomes | Lower is better. Penalizes "far off" predictions more |
+| ECE | Need calibration number | Lower is better. 0 = perfectly calibrated |
+| Per-class calibration | Always for classification | Points should track the diagonal |
+| Accuracy | Stakeholder communication only | Ignores probability quality — never use alone |
+
+## Temporal and out-of-sample evaluation
+
+For panel data or time-series-adjacent data (e.g., multiple seasons), always evaluate **per time period**:
+
+```python
+for period in sorted(data_oos["season"].unique()):
+    mask = data_oos["season"] == period
+    period_metrics = evaluate(pred_probs[mask], actuals[mask])
+    print(f"{period}: {period_metrics}")
+```
+
+This reveals **temporal degradation** — a model that works well on 2020 but poorly on 2023 may be overfitting to historical patterns. If you see degradation, consider whether the data-generating process has changed (concept drift) or whether the training window needs expanding.
+
+## Feature importance for shrinkage models
+
+When using sparsity priors (horseshoe, R2-D2), summarize feature relevance via **probability of practical significance**:
+
+```python
+beta_samples = idata.posterior["beta"].stack(samples=("chain", "draw")).values
+threshold = 0.05  # on the standardized coefficient scale
+
+importance = pd.DataFrame({
+    "feature": features,
+    "posterior_mean": beta_samples.mean(axis=-1),
+    "posterior_sd": beta_samples.std(axis=-1),
+    "P(|beta|>threshold)": (np.abs(beta_samples) > threshold).mean(axis=-1),
+}).sort_values("P(|beta|>threshold)", ascending=False)
+```
+
+This is more informative than just looking at posterior means — it tells you the **probability that each feature has a practically meaningful effect**, which is the natural Bayesian answer to "which features matter?"
+
 ## Decision workflow
 
 After running diagnostics:

--- a/bayesian-workflow/references/priors.md
+++ b/bayesian-workflow/references/priors.md
@@ -4,6 +4,7 @@
 - Philosophy: why priors matter
 - Weakly informative priors (the default)
 - Prior families by parameter type
+- Sparsity priors (high-dimensional regression)
 - Prior predictive checking workflow
 - Common mistakes
 
@@ -72,6 +73,85 @@ chol, corr, stds = pm.LKJCholeskyCov(
 | Degrees of freedom (StudentT) | Gamma(2, 0.1) or Exponential(1/30) + shift | Keeps ν reasonable (not too low, not → ∞) |
 | Ordinal cutpoints | Normal with ordered transform | Maintains ordering |
 | Categorical predictors or Group-level intercepts | ZeroSumNormal | Ensures sum to zero and avoids over-parametrization. Similar to reference-encoding but more appropriate when no obvious placebo/reference category exists |
+
+## Sparsity priors (high-dimensional regression)
+
+When you have many features and expect only a subset to be relevant, use a sparsity-inducing prior instead of a shared Normal. These adaptively shrink irrelevant coefficients toward zero while preserving signal from important ones.
+
+### When to use sparsity priors
+
+| Situation | Prior recommendation |
+|-----------|---------------------|
+| Few features (< ~10), all plausibly relevant | Normal(0, σ) — sparsity is overkill |
+| Many features, expected sparsity | Regularized Horseshoe or R2-D2 |
+| Many features, want interpretable R² | R2-D2 |
+| Variable selection (hard zeros) | Use BART or kulprit instead — spike-and-slab is rarely worth the complexity in PyMC |
+
+### Regularized Horseshoe (Finnish Horseshoe)
+
+The go-to sparsity prior. Shrinks irrelevant features toward zero ("spike") while allowing strong signals through ("slab"). Always use the **regularized** variant (Piironen & Vehtari, 2017) — the original horseshoe has a double-funnel geometry that causes divergences.
+
+```python
+import pytensor.tensor as pt
+
+D = X.shape[1]  # number of features
+N = X.shape[0]  # number of observations
+p0 = 5  # prior guess for number of relevant features
+
+# Global shrinkage — controls overall sparsity
+tau = pm.HalfStudentT("tau", nu=2, sigma=p0 / (D - p0) / np.sqrt(N))
+
+# Local shrinkage — per-feature
+lam = pm.HalfStudentT("lam", nu=5, shape=D)
+
+# Slab — regularizes large coefficients (prevents double-funnel)
+c2 = pm.InverseGamma("c2", alpha=1, beta=1)
+
+# Effective shrinkage
+lam_tilde = pt.sqrt(c2 * lam**2 / (c2 + tau**2 * lam**2))
+
+# Coefficients
+beta_raw = pm.Normal("beta_raw", mu=0, sigma=1, shape=D)
+beta = pm.Deterministic("beta", beta_raw * tau * lam_tilde, dims="feature")
+```
+
+Key hyperparameter: `p0` (expected number of relevant features). This controls the global shrinkage `tau`. Be honest about your prior belief — setting `p0` too high defeats the purpose of sparsity.
+
+**Practical tip**: With horseshoe models, always use `target_accept=0.95` or higher.
+
+**Feature importance with horseshoe**: After fitting, compute `P(|β| > threshold)` per feature to rank practical significance:
+
+```python
+beta_samples = idata.posterior["beta"].values  # (chains, draws, D)
+threshold = 0.05  # adjust based on scale
+prob_relevant = (np.abs(beta_samples) > threshold).mean(axis=(0, 1))
+```
+
+### R2-D2 prior
+
+An alternative where you specify prior beliefs about the total R² (variance explained) rather than per-feature shrinkage. More interpretable when you have a prior sense of overall model fit.
+
+```python
+import pytensor.tensor as pt  # if not already imported above
+
+# Prior on R² (proportion of variance explained)
+R2 = pm.Beta("R2", alpha=1, beta=1)  # uniform on [0, 1] — adjust based on domain
+
+# Concentration parameter controls how R² is distributed across features
+# Higher concentration = more uniform; lower = more sparse
+phi = pm.Dirichlet("phi", a=np.ones(D), shape=D)
+
+# Coefficient variances derived from R²
+sigma2_y = pm.HalfNormal("sigma2_y", sigma=1)  # residual variance
+tau2 = R2 / (1 - R2) * sigma2_y * phi
+
+beta = pm.Normal("beta", mu=0, sigma=pt.sqrt(tau2), dims="feature")
+```
+
+Use R2-D2 when:
+- You have domain knowledge about how much variance the model should explain
+- You want a more interpretable parameterization than the horseshoe
+- The horseshoe's funnel causes persistent divergences even with regularization
 
 ## Prior predictive checking workflow
 


### PR DESCRIPTION
## Summary

- Closes gaps revealed by real-world evaluation on @maxi-tb22 SFMMO (Soccer Factor Model for Match Outcomes), an ordered logistic hierarchical model with ~10K matches across 5 European leagues
- Adds guidance for sparsity priors, classification/ordinal evaluation, model identifiability, and out-of-sample predictions
- Version bump: 1.0 → 1.1

## What changed

### SKILL.md
- **3 new critical rules**: always use posterior mean (not median) for predictive probabilities; use `pm.set_data()` for OOS predictions; check model identifiability before interpreting components
- **6 new model families**: zero-inflated, hurdle, ordinal, censored, truncated, sparse regression
- **2 new gotchas**: horseshoe double-funnel geometry, `np.median` silent bug
- **1 new troubleshooting row**: Pathfinder initialization via `pymc_extras`
- Fix pre-existing typo ("aggregted" → "aggregated")

### references/priors.md
- **New section: sparsity priors** — regularized horseshoe (Piironen & Vehtari 2017) with full code template, R2-D2 prior, decision table for when to use each

### references/model-criticism.md
- **New section: classification/ordinal evaluation** — ECE, RPS, per-class calibration plots, metrics summary table
- **New section: temporal evaluation** — per-period OOS splits to detect concept drift
- **New section: feature importance for shrinkage models** — P(|β| > threshold) as the Bayesian answer to "which features matter?"

### references/hierarchical.md
- **New section: identifiability checks** — 3 common traps (always-active offsets, overparameterized intercepts, group-level collinearity), detection via `az.plot_pair()`, remediation strategies

## Motivation

The wSKILL agent in Max's evaluation followed the workflow discipline correctly (prior predictive checks, non-centered parameterization, R-hat 1.01, descriptive seeds) but had gaps: it used `np.median` instead of `np.mean` for predictions, missed sparsity priors, and didn't warn about identifiability. The woSKILL agent independently produced a richer evaluation suite (ECE, per-class calibration, temporal breakdown) that our skill didn't guide toward. These additions close those gaps.

## Test plan

- [x] Re-run existing eval scenarios (6 test cases) to verify no regressions
- [x] Verify new content doesn't break skill loading (file sizes within limits)
- [x] Manual review of sparsity prior code templates against PyMC docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)