### PR TITLE
Add prior sensitivity checks to bayesian-workflow skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,6 @@ __marimo__/
 .streamlit/secrets.toml
 
 blog-posts/
+
+# Internal working docs (specs, plans)
+docs/

--- a/bayesian-workflow/SKILL.md
+++ b/bayesian-workflow/SKILL.md
@@ -2,19 +2,20 @@
 name: bayesian-workflow
 description: >
   Opinionated Bayesian modeling workflow with PyMC and ArviZ. Contains critical guardrails
-  (nutpie sampler, prior/posterior predictive checks, LOO-PIT calibration, 94% HDI, non-centered
-  parameterizations, reproducible seeds) that agents won't apply unprompted — always consult
-  before writing Bayesian model code. Trigger on: building probabilistic/Bayesian models, prior
-  elicitation, MCMC inference, convergence diagnostics (divergences, R-hat, ESS), model comparison
-  (LOO-CV, ELPD, stacking weights), hierarchical/multilevel models, count regressions, logistic
-  regression with uncertainty, reporting Bayesian results, or mentions of PyMC, ArviZ,
-  InferenceData, credible intervals, posterior distributions, shrinkage, uncertainty quantification.
-  Also trigger for model comparison, diagnosing sampling problems, choosing priors, or presenting
-  stats to non-technical audiences.
+  (nutpie sampler, prior/posterior predictive checks, LOO-PIT calibration, prior sensitivity
+  checks, 94% HDI, non-centered parameterizations, reproducible seeds) that agents won't
+  apply unprompted — always consult before writing Bayesian model code. Trigger on: building
+  probabilistic/Bayesian models, prior elicitation, MCMC inference, convergence diagnostics
+  (divergences, R-hat, ESS), model comparison (LOO-CV, ELPD, stacking weights),
+  hierarchical/multilevel models, count regressions, logistic regression with uncertainty,
+  prior sensitivity analysis, reporting Bayesian results, or mentions of PyMC, ArviZ,
+  InferenceData, credible intervals, posterior distributions, shrinkage, uncertainty
+  quantification. Also trigger for model comparison, diagnosing sampling problems, choosing
+  priors, or presenting stats to non-technical audiences.
 license: MIT
 metadata:
   author: [Alexandre Andorra](https://alexandorra.github.io/)
-  version: "1.1"
+  version: "1.2"
 ---
 
 # Bayesian Workflow
@@ -30,8 +31,9 @@ Every Bayesian analysis follows this sequence. Do not skip steps -- especially m
 5. **Inference** — `pm.sample(nuts_sampler="nutpie")`. Always use nutpie for speed (the nutpie python package provides cutting-edge sampling). Don't hardcode the number of chains — let the sampler pick the best default for the platform.
 6. **Diagnose convergence** — Use `arviz_stats.diagnose(idata)` as the first check (requires arviz-stats >= 1.0.0). It covers R-hat, ESS, divergences, tree depth, and E-BFMI in one call. See [references/diagnostics.md](references/diagnostics.md)
 7. **Criticize the model** — See [references/model-criticism.md](references/model-criticism.md)
-8. **Compare models** (if applicable) — See [references/model-comparison.md](references/model-comparison.md)
-9. **Report results** — See [references/reporting.md](references/reporting.md). When the user asks for a report or mentions a non-technical audience, generate a **standalone markdown report file** (not just code comments) using the template in reporting.md. Adapt the language to the audience — if they're new to Bayesian stats, include a glossary and plain-language explanations of key concepts.
+8. **Check prior sensitivity** — Run `psense_summary(idata)` to verify conclusions are robust to prior choices. Visualize with `plot_psense_dist(idata)` from `arviz_plots`. Requires `log_likelihood` and `log_prior` in the InferenceData — compute them after sampling if needed. See [references/sensitivity.md](references/sensitivity.md)
+9. **Compare models** (if applicable) — See [references/model-comparison.md](references/model-comparison.md)
+10. **Report results** — See [references/reporting.md](references/reporting.md). When the user asks for a report or mentions a non-technical audience, generate a **standalone markdown report file** (not just code comments) using the template in reporting.md. Adapt the language to the audience — if they're new to Bayesian stats, include a glossary and plain-language explanations of key concepts.
 
 ## Installation
 
@@ -61,7 +63,7 @@ with pm.Model(coords=coords) as model:
     # Always document WHY each prior was chosen
     mu = pm.Normal("mu", mu=0, sigma=10)  # Weakly informative: allows wide range
 
-    # --- Likelihood ---
+    # --- Data model ---
     pm.Normal("obs", mu=mu, sigma=1, observed=data, dims="obs")
 
     # --- Prior predictive check ---
@@ -73,6 +75,10 @@ with pm.Model(coords=coords) as model:
 
     # --- Posterior predictive check ---
     idata.extend(pm.sample_posterior_predictive(idata, random_seed=rng))
+
+    # --- Compute log-likelihood and log-prior for sensitivity checks & LOO ---
+    pm.compute_log_likelihood(idata, model=model)
+    pm.compute_log_prior(idata, model=model)
 
     # --- Save immediately after sampling ---
     # Late crashes can destroy valid results. Save to disk before any post-processing.
@@ -108,7 +114,7 @@ with model:
 
 ## Common model families
 
-| Problem | Likelihood | Typical priors | Reference |
+| Problem | Data model | Typical priors | Reference |
 |---|---|---|---|
 | Continuous outcome | Normal / StudentT | Normal, Gamma avoiding 0 for positive-constrained parameters | [references/priors.md](references/priors.md) |
 | Binary outcome | Bernoulli or Binomial if aggregated, with logit inverse-link | Normal(0, 1.5) on coeffs | [references/priors.md](references/priors.md) |
@@ -142,7 +148,7 @@ See [scripts/](scripts/) for all available utilities.
 
 These are battle-tested lessons that save hours of debugging:
 
-- **nutpie silently ignores `idata_kwargs={"log_likelihood": True}`**. If you need log-likelihood (for LOO-CV), call `pm.compute_log_likelihood(idata, model=model)` after sampling. This is a known issue — don't assume it's stored automatically.
+- **nutpie silently ignores `idata_kwargs`** for `log_likelihood` and `log_prior`. Always compute them explicitly after sampling: `pm.compute_log_likelihood(idata, model=model)` (needed for LOO-CV) and `pm.compute_log_prior(idata, model=model)` (needed for prior sensitivity checks). Don't assume they're stored automatically.
 - **`az.plot_khat()` requires the LOO object**, not InferenceData. Pass the output of `az.loo(idata, pointwise=True)` to it.
 - **Flat priors on scale parameters** (`HalfCauchy`, `HalfFlat`) cause funnels in hierarchical models. Use `Gamma(2, ...)` or `Exponential` — these avoid the near-zero region that creates sampling problems. If there's no group-level variation to detect, you don't need the hierarchy.
 - **Python conditionals in models** (`if x > 0`) don't work inside PyMC. Use `pm.math.switch` or `pytensor.tensor.where` instead.
@@ -158,7 +164,8 @@ These are battle-tested lessons that save hours of debugging:
 | Low ESS | High autocorrelation | More tuning steps, reparameterize, reduce correlations |
 | R-hat > 1.01 | Chains haven't mixed | More draws, better initialization, check for multimodality |
 | Prior pred. looks wrong | Bad priors | Tighten or shift priors, use domain knowledge |
-| Post. pred. misses data | Model misspecification | Add complexity (varying slopes, different likelihood, interaction terms) |
+| Post. pred. misses data | Model misspecification | Add complexity (varying slopes, different data model, interaction terms) |
 | `log_likelihood` missing | nutpie doesn't auto-store it | Call `pm.compute_log_likelihood(idata, model=model)` after sampling |
 | Slow model | Large Deterministics or recompilation | Profile with `model.profile(model.logp())`, avoid large `Deterministic` arrays |
 | Slow to initialize / poor warmup | Bad starting point | Try `init="adapt_diag_grad"` in `pm.sample()`, or run `pmx.fit(method="pathfinder")` first (`import pymc_extras as pmx`) and pass its estimates as `initvals` |
+| Prior sensitivity flag | Prior-data conflict or strong prior | Check `psense_summary(idata)` — see [references/sensitivity.md](references/sensitivity.md). Justify or revise the flagged prior |

--- a/bayesian-workflow/references/diagnostics.md
+++ b/bayesian-workflow/references/diagnostics.md
@@ -2,7 +2,7 @@
 
 ## Contents
 - Quick diagnostic checklist
-- R-hat (Gelman-Rubin)
+- R-hat
 - Effective sample size (ESS)
 - Divergences
 - Trace plots and rank plots
@@ -34,7 +34,7 @@ az.plot_trace(idata, kind="rank_vlines")
 
 If `azs.diagnose` is not available (arviz-stats < 1.0.0), fall back to the manual checks below.
 
-## R-hat (Gelman-Rubin)
+## R-hat
 
 Measures agreement across chains. Uses the rank-normalized split-R-hat (ArviZ default).
 

--- a/bayesian-workflow/references/hierarchical.md
+++ b/bayesian-workflow/references/hierarchical.md
@@ -43,8 +43,8 @@ with pm.Model(coords=coords) as centered:
     mu_group = pm.Normal("mu_group", mu=mu_global, sigma=sigma_global, dims="group")
     sigma_obs = pm.Gamma("sigma_obs", 2, 2)
     
-    # or whatever the likelihood is
-    pm.Normal("likelihood", mu=mu_group[group_idx], sigma=sigma_obs, observed=y, dims="obs")
+    # or whatever the data model is
+    pm.Normal("obs", mu=mu_group[group_idx], sigma=sigma_obs, observed=y, dims="obs")
 ```
 
 ```python
@@ -60,8 +60,8 @@ with pm.Model() as noncentered:
     mu_raw = pm.Normal("mu_raw", mu=0, sigma=1, dims="group")
     mu_group = pm.Deterministic("mu_group", mu_global + mu_raw * sigma_global, dims="group")
     
-    # or whatever the likelihood is
-    pm.Normal("likelihood", mu=mu_group[group_idx], sigma=sigma_obs, observed=y, dims="obs")
+    # or whatever the data model is
+    pm.Normal("obs", mu=mu_group[group_idx], sigma=sigma_obs, observed=y, dims="obs")
 ```
 
 **Rule of thumb**: Start with non-centered. Switch to centered only if non-centered shows poor ESS AND groups have substantial data (50+ observations each).
@@ -75,7 +75,7 @@ Each group has its own baseline, partially pooled toward a global mean.
 ```python
 # This is the centered parameterization
 mu_group = pm.Normal("mu_group", mu=mu_global, sigma=sigma_global, dims="group")
-pm.Normal("likelihood", mu=mu_group[group_idx], sigma=sigma_obs, observed=y, dims="obs")
+pm.Normal("obs", mu=mu_group[group_idx], sigma=sigma_obs, observed=y, dims="obs")
 ```
 
 ### Varying intercepts and slopes

--- a/bayesian-workflow/references/model-comparison.md
+++ b/bayesian-workflow/references/model-comparison.md
@@ -9,7 +9,7 @@
 
 ## When to compare models
 
-Compare models when you have genuinely different modeling assumptions — not for variable selection. Bayesian model comparison answers: "Which model predicts unseen data better?", and need the same likelihood for all models being compared.
+Compare models when you have genuinely different modeling assumptions — not for variable selection. Bayesian model comparison answers: "Which model predicts unseen data better?" LOO-CV works across different data models — they do not need to share the same observation distribution (see [CV-FAQ](https://users.aalto.fi/~ave/CV-FAQ.html#differentmodels)).
 
 For variable selection, use a [BART model](https://github.com/pymc-devs/pymc-bart), or the [kulprit package](https://github.com/bambinos/kulprit).
 

--- a/bayesian-workflow/references/model-criticism.md
+++ b/bayesian-workflow/references/model-criticism.md
@@ -106,7 +106,7 @@ A sharper calibration check. If the model is calibrated, PIT values should be un
 
 ## Simulation-based calibration (SBC)
 
-SBC validates that the entire inference pipeline is correct — priors, likelihood, sampler, and code. It simulates data from the prior, fits the model, and checks that posterior rank statistics are uniform.
+SBC validates that the entire inference pipeline is correct — priors, data model, sampler, and code. It simulates data from the prior, fits the model, and checks that posterior rank statistics are uniform.
 
 This is the gold standard for validating a new model implementation. Run it once per model specification, if you have doubts about the model, since SBC is computationally expensive.
 
@@ -120,7 +120,7 @@ Use the [simuk package](https://github.com/arviz-devs/simuk), either directly, o
 **When to run SBC**:
 - Developing a new model you'll reuse
 - Complex hierarchical models where bugs are easy to introduce
-- Custom likelihoods or potentials
+- Custom data models or potentials
 - Not necessary for routine analyses with standard model families
 
 ## Residual analysis
@@ -260,7 +260,7 @@ After running diagnostics:
    YES ↓
 
 2. Posterior predictive check pass?
-   NO  → Model misspecification. Revise likelihood or add complexity.
+   NO  → Model misspecification. Revise data model or add complexity.
    YES ↓
 
 3. LOO-CV: any high Pareto k?
@@ -268,7 +268,7 @@ After running diagnostics:
    NO  ↓
 
 4. Calibration OK?  (coverage + PIT)
-   NO  → Model is mis-calibrated. Check priors, likelihood, missing predictors.
+   NO  → Model is mis-calibrated. Check priors, data model, missing predictors.
    YES ↓
 
 5. Residual patterns?

--- a/bayesian-workflow/references/reporting.md
+++ b/bayesian-workflow/references/reporting.md
@@ -82,6 +82,15 @@ Use this structure for written reports. Adapt sections as needed.
 |-------|------|----|-------|--------|
 [comparison table]
 
+### Prior sensitivity
+| Parameter | Prior CJS | Likelihood CJS | Diagnostic |
+|-----------|-----------|----------------|------------|
+| β₁ | 0.02 | 0.01 | Low sensitivity ✓ |
+| σ | 0.08 | 0.03 | Strong prior / weak likelihood — justified by [domain rationale] |
+
+[Brief interpretation: which parameters are sensitive, whether this affects conclusions,
+and justification for any retained informative priors.]
+
 ## Interpretation
 [What do the results mean substantively? Discuss effect sizes, practical significance,
 and how uncertainty affects conclusions. Be explicit about what the model does NOT tell us.]
@@ -193,5 +202,5 @@ The report template above is for a technical audience. When the user mentions a 
 2. **Using frequentist language**: Avoid "significant", "p < 0.05", "fail to reject". Use "probability", "credible interval", "posterior probability of direction."
 3. **Hiding diagnostics**: If convergence was imperfect, say so. If you had to fix divergences, describe how.
 4. **Ignoring practical significance**: A posterior that excludes zero is not automatically important. Discuss effect sizes in context.
-5. **Not showing prior sensitivity**: For controversial results, show how conclusions change (or not) under alternative priors.
+5. **Not showing prior sensitivity**: Run `psense_summary(idata)` and report the results — especially for policy-relevant or controversial conclusions. Show the CJS values table, flag any parameters with CJS > 0.05, and briefly explain whether the sensitivity affects your conclusions. If you have an intentionally informative prior that flags as sensitive, justify it explicitly rather than hiding the diagnostic. Readers should know which conclusions depend on prior choices and which are robust.
 6. **Skipping the generative story**: The model specification should make clear what process is assumed to have generated the data.

--- a/bayesian-workflow/references/sensitivity.md
+++ b/bayesian-workflow/references/sensitivity.md
@@ -1,0 +1,101 @@
+# Prior Sensitivity Analysis
+
+Power-scaling sensitivity analysis checks whether your posterior conclusions are robust to reasonable changes in prior (or likelihood) strength — without refitting the model. It uses Pareto-smoothed importance sampling (PSIS) to simulate what would happen if you made your priors stronger or weaker.
+
+## Contents
+- Requirements
+- Running sensitivity checks
+- Interpreting results
+- Which variables to check
+- Visual diagnostics
+- Key principle
+
+## Requirements
+
+The InferenceData object must contain both `log_likelihood` and `log_prior` groups.
+
+**Important**: nutpie silently ignores `idata_kwargs={"log_likelihood": True}` and `idata_kwargs={"log_prior": True}`. You must compute these after sampling:
+
+```python
+# After pm.sample():
+pm.compute_log_likelihood(idata, model=model)
+pm.compute_log_prior(idata, model=model)
+```
+
+Verify they're present before running sensitivity checks:
+
+```python
+assert "log_likelihood" in idata, "Missing log_likelihood — run pm.compute_log_likelihood(idata, model=model)"
+assert "log_prior" in idata, "Missing log_prior — run pm.compute_log_prior(idata, model=model)"
+```
+
+## Running sensitivity checks
+
+```python
+from arviz_stats import psense_summary
+
+summary = psense_summary(idata)
+summary
+```
+
+This returns a per-variable table with Cumulative Jensen-Shannon (CJS) divergence values for both prior and likelihood perturbations. CJS > 0.05 flags sensitivity (roughly equivalent to a 0.3 standard deviation shift in the posterior mean).
+
+## Interpreting results
+
+Four diagnostic patterns:
+
+| Pattern | Prior CJS | Likelihood CJS | What it means | What to do |
+|---------|-----------|----------------|---------------|------------|
+| **Low sensitivity** | < 0.05 | < 0.05 | Posterior is robust to prior/likelihood changes | Nothing — this is the ideal outcome |
+| **Prior-data conflict** | > 0.05 | > 0.05 | Prior and data pull in different directions | Investigate whether the prior reflects genuine domain knowledge or is just wrong. Consider empirically-scaled priors (e.g., `β ~ Normal(0, 2.5 * sd_y / sd_x)`) |
+| **Strong prior / weak likelihood** | > 0.05 | < 0.05 | Prior dominates the posterior | Check if this is intentional (e.g., strong domain constraint). If not, weaken the prior or collect more data |
+| **Likelihood-driven** | < 0.05 | > 0.05 | Data dominates the posterior | Usually fine — note in report for transparency |
+
+## Which variables to check
+
+Not every parameter needs sensitivity analysis. Focus on what matters:
+
+- **Check**: interpretable coefficients, effect sizes, predictions, derived quantities (e.g., Bayesian R², contrasts)
+- **Skip**: group-specific parameters in hierarchical models (power-scale only the top-level hyperpriors), spline/GP basis coefficients, variance components you don't interpret directly
+
+For hierarchical models, sensitivity of the hyperprior (e.g., the group-level standard deviation) is more informative than sensitivity of individual group effects.
+
+```python
+# Check only specific variables
+summary = psense_summary(idata, var_names=["beta", "sigma"])
+```
+
+## Visual diagnostics
+
+### `plot_psense_dist` — How the posterior shifts
+
+Shows posterior marginals at three power-scaling levels (α = 0.8, 1.0, 1.25). Use this to see the *direction and magnitude* of the shift, not just whether it exceeds the threshold.
+
+```python
+from arviz_plots import plot_psense_dist
+
+plot_psense_dist(idata, var_names=["beta"])
+```
+
+Requires `arviz-plots` (`pip install arviz-plots`).
+
+### `plot_psense_quantities` — Sensitivity of derived quantities
+
+Shows how predictions or summary statistics shift under perturbation. Use this when you care more about predictive robustness than individual parameter sensitivity.
+
+```python
+from arviz_plots import plot_psense_quantities
+
+plot_psense_quantities(idata)
+```
+
+## Key principle
+
+**Sensitivity warnings are not automatic problems.** An intentionally informative prior — grounded in domain knowledge or previous studies — will legitimately flag as sensitive. That's expected: if you have a strong prior and modest data, the prior *should* matter.
+
+The correct response to a sensitivity flag is:
+1. **Document** the flag and its magnitude
+2. **Justify** why the prior is appropriate (or acknowledge it isn't)
+3. **Report** the sensitivity transparently — readers should know which conclusions depend on prior choices
+
+Do not reflexively loosen priors to silence diagnostics. A well-justified informative prior that flags sensitivity is better science than a vague prior that passes all checks but encodes no knowledge.

--- a/bayesian-workflow/references/sensitivity.md
+++ b/bayesian-workflow/references/sensitivity.md
@@ -1,4 +1,4 @@
-# Prior Sensitivity Analysis
+# Prior/Likelihood Sensitivity Analysis
 
 Power-scaling sensitivity analysis checks whether your posterior conclusions are robust to reasonable changes in prior (or likelihood) strength — without refitting the model. It uses Pareto-smoothed importance sampling (PSIS) to simulate what would happen if you made your priors stronger or weaker.
 

--- a/environment.yml
+++ b/environment.yml
@@ -12,5 +12,6 @@ dependencies:
   - pip
   - pip:
     - arviz-stats>=1.0.0
+    - arviz-plots>=1.0.0
     - causalpy>=0.8
     - dowhy>=0.14


### PR DESCRIPTION
## Summary

  Adds power-scaling prior sensitivity checks as a new Step 8 in the bayesian-workflow skill (v1.1 --> v1.2), using ArviZ's `psense_summary`, `plot_psense_dist`, and `plot_psense_quantities`. Requested by @aloctavodia in #6 -- ready for your review if you're down for it Osvaldo :)

Also incorporates terminology fixes from Aki Vehtari's review:
  - "Likelihood" --> "Data model" where referring to the observation model ([context](https://statmodeling.stat.columbia.edu/2026/03/20/a-data-model-is-not-just-a-likelihood/))
  - "R-hat (Gelman-Rubin)" --> "R-hat" (modern R-hat is not the 1992 version)
  - LOO-CV works across different data models: they don't need the same observation distribution ([CV-FAQ](https://users.aalto.fi/~ave/CV-FAQ.html#differentmodels))

### What's new
  - `references/sensitivity.md` -- full reference doc: requirements, workflow, interpretation (4 diagnostic patterns), which variables to check, visual diagnostics
  - Step 8 in SKILL.md: `psense_summary` + `plot_psense_dist`, with link to reference
  - `references/reporting.md`: sensitivity section in report template + expanded common mistake nbr 5
  - `arviz-plots` added to `environment.yml`

  ### Terminology fixes (across all reference docs)
  - `SKILL.md`: table column "Likelihood" --> "Data model", comment and troubleshooting fixes
  - `model-comparison.md`: removed incorrect "same likelihood" requirement
  - `model-criticism.md`: "Revise likelihood" --> "Revise data model" in decision workflow
  - `hierarchical.md`: `pm.Normal("likelihood", ...)` --> `pm.Normal("obs", ...)`
  - `diagnostics.md`: "R-hat (Gelman-Rubin)" --> "R-hat"

  Closes #6