### PR TITLE
Portable reporting harness + skill improvements (bayesian-workflow v1.4, causal-inference v1.2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,21 +8,23 @@
 
 ```
 baygent-skills/
-├── bayesian-workflow/          # Shipped skill (v1.2)
+├── bayesian-workflow/          # Shipped skill (v1.4)
 │   ├── SKILL.md                # Main workflow instructions
-│   ├── references/             # Detailed reference docs (priors, diagnostics, sensitivity, etc.)
-│   └── scripts/                # Utility scripts (diagnose_model.py, calibration_check.py)
-├── causal-inference/           # Shipped skill (v1.0)
+│   ├── references/             # Detailed reference docs (priors, diagnostics, sensitivity, reporting)
+│   └── scripts/                # diagnose_model.py, calibration_check.py, check_diagnostics.py
+├── causal-inference/           # Shipped skill (v1.2)
 │   ├── SKILL.md                # Main workflow instructions (depends on bayesian-workflow)
-│   └── references/             # DAGs, quasi-experiments, structural models, refutation, reporting
-├── amortized-workflow/         # Shipped skill (v1.0, co-authored with Stefan Radev)
+│   ├── references/             # DAGs, quasi-experiments, structural models, refutation, reporting
+│   └── scripts/                # check_refutation.py (calibrated causal language harness)
+├── amortized-workflow/         # Shipped skill (v2.0, co-authored with Stefan Radev)
 │   ├── SKILL.md                # Amortized Bayesian workflow with BayesFlow
-│   ├── references/             # Adapters, conditioning logic, model sizes
-│   └── scripts/                # Utility scripts (check_diagnostics.py, inspect_training.py)
+│   ├── references/             # Adapters, conditioning logic, model sizes, reporting
+│   └── scripts/                # check_diagnostics.py, inspect_training.py
 ├── evals/                         # Eval scenarios and benchmarks
 │   ├── bayesian-workflow/         # 6 scenarios, 3 iterations
 │   ├── causal-inference/          # 6 scenarios
-│   └── amortized-workflow/        # 6 scenarios + trigger set + benchmark results
+│   ├── amortized-workflow/        # 6 scenarios + trigger set + benchmark results
+│   └── smoke/                     # Integration smoke test for the reporting harness pipeline
 ├── environment.yml             # Mamba/conda env definition (env name: baygent)
 ├── LICENSE                     # MIT
 └── CLAUDE.md                   # This file
@@ -42,6 +44,11 @@ Every skill follows the Agent Skills spec:
 - `scripts/` for utility scripts
 - Description must be agent-neutral (no "Claude"-specific language)
 
+### Skill authoring heuristics
+- **The `description` is the only thing the agent sees when deciding to load the skill.** Lead with what it does, then an explicit "Use when …" trigger sentence listing concrete keywords/situations. This is the single highest-leverage field.
+- **Keep `SKILL.md` lean; push depth to `references/`.** The main file is the always-loaded budget — progressive disclosure, link out for detail.
+- **Prefer a script over generated code for deterministic, repeated, or error-prone operations.** Scripts save tokens and run consistently; reserve inline code for one-off, model-specific logic.
+
 ### Code style
 - PyMC 5+ syntax with coords and dims
 - nutpie sampler by default
@@ -52,3 +59,4 @@ Every skill follows the Agent Skills spec:
 - All evals now in `evals/` (bayesian-workflow, causal-inference, amortized-workflow)
 - Benchmark target: 100% with skill vs ~90% without
 - Each eval has: `eval_metadata.json` (prompt + assertions), `with_skill/` and `without_skill/` outputs + grading
+- **Reporting harness smoke test** (`evals/smoke/test_reporting_harness.py`): runs the bayesian diagnostics pipeline (`diagnose_model → calibration_check → check_diagnostics`) end-to-end on a tiny model and the causal `check_refutation` harness on fixtures. Run after any change to the `scripts/` of either skill: `conda run -n baygent python evals/smoke/test_reporting_harness.py`. Guards JSON-serializability, the diagnose→check schema contract, and refutation metric direction.

--- a/bayesian-workflow/README.md
+++ b/bayesian-workflow/README.md
@@ -19,9 +19,9 @@ Guides your coding agent through the full Bayesian workflow:
 7. **Model criticism** (posterior predictive checks, LOO-PIT calibration)
 8. **Prior/likelihood sensitivity** (power-scaling via PSIS)
 9. **Model comparison** (LOO-CV, ELPD, stacking weights)
-10. **Reporting** with companion analysis notes and audience-adapted reports
+10. **Reporting** with a canonical `<slug>/report.md` artifact and audience-adapted prose
 
-The skill enforces guardrails that agents won't apply on their own: 94% HDI, mandatory calibration checks, prior/likelihood sensitivity checks, non-centered parameterizations for hierarchical models, reproducible descriptive seeds, immediate save-to-disk after sampling, and xarray-first data manipulation.
+The skill enforces guardrails that agents won't apply on their own: 94% HDI, mandatory calibration checks, prior/likelihood sensitivity checks, non-centered parameterizations for hierarchical models, reproducible descriptive seeds, immediate save-to-disk after sampling, xarray-first data manipulation, a NUTS sampling-failure escalation ladder, discrete-latent marginalization over soft plug-ins, and a canonical report artifact whose Assessment lines and Suggested Next Steps come from a programmatic harness — not hand-rolled prose.
 
 ## Install
 
@@ -80,8 +80,9 @@ bayesian-workflow/
 │   ├── sensitivity.md                # Prior/likelihood sensitivity analysis (power-scaling)
 │   └── reporting.md                  # Report templates, audience adaptation
 └── scripts/
-    ├── diagnose_model.py             # Post-sampling diagnostics report
-    └── calibration_check.py          # Calibration plots from InferenceData
+    ├── diagnose_model.py             # Post-sampling diagnostics report (writes diagnostics.json)
+    ├── calibration_check.py          # Calibration plots from InferenceData (writes calibration.json)
+    └── check_diagnostics.py          # Interprets diagnostics + calibration into qualitative ratings + suggested next steps
 ```
 
 ## License

--- a/bayesian-workflow/SKILL.md
+++ b/bayesian-workflow/SKILL.md
@@ -15,7 +15,7 @@ description: >
 license: MIT
 metadata:
   author: [Alexandre Andorra](https://alexandorra.github.io/)
-  version: "1.2"
+  version: "1.4"
 ---
 
 # Bayesian Workflow
@@ -33,7 +33,7 @@ Every Bayesian analysis follows this sequence. Do not skip steps -- especially m
 7. **Criticize the model** — See [references/model-criticism.md](references/model-criticism.md)
 8. **Check prior sensitivity** — Run `psense_summary(idata)` to verify conclusions are robust to prior choices. Visualize with `plot_psense_dist(idata)` from `arviz_plots`. Requires `log_likelihood` and `log_prior` in the InferenceData — compute them after sampling if needed. See [references/sensitivity.md](references/sensitivity.md)
 9. **Compare models** (if applicable) — See [references/model-comparison.md](references/model-comparison.md)
-10. **Report results** — See [references/reporting.md](references/reporting.md). When the user asks for a report or mentions a non-technical audience, generate a **standalone markdown report file** (not just code comments) using the template in reporting.md. Adapt the language to the audience — if they're new to Bayesian stats, include a glossary and plain-language explanations of key concepts.
+10. **Report results** — Generate `<slug>/report.md` using the canonical template in [references/reporting.md](references/reporting.md). Run `scripts/check_diagnostics.py` to turn raw diagnostics into qualitative ratings + an ordered next-steps list, and use that output to fill the Assessment lines and Suggested Next Steps section. When the user mentions a non-technical audience or is new to Bayesian stats, additionally adapt the prose to plain language and include a glossary — but keep the canonical report structure as the audit trail.
 
 ## Installation
 
@@ -99,7 +99,8 @@ with pm.Model(coords=coords) as model:
 - **Save InferenceData immediately after sampling** with `idata.to_netcdf("model_output.nc")`. Late crashes or kernel restarts can destroy valid MCMC results — save before any post-processing.
 - **Use ArviZ for all plots and calibration.** Don't write custom plotting code when ArviZ already handles it — including for binary data, count data, and calibration. ArviZ developers have thought through edge cases so you don't have to.
 - **Prefer xarray over numpy for InferenceData operations.** `InferenceData` and `DataTree` objects are backed by xarray — use xarray's labeled indexing (`.sel()`, `.mean(dim=...)`, etc.) instead of converting to numpy arrays. This preserves dimension labels, avoids shape bugs, and makes code more readable. Fall back to numpy only when xarray can't do what you need.
-- **Always generate analysis notes alongside code.** When producing a model script, also produce a companion markdown file (`analysis_notes.md` or similar) that interprets the results — what the diagnostics mean, what the posteriors tell us, what the calibration plots show. Code without interpretation is incomplete.
+- **Always generate `<slug>/report.md` after a full analysis run.** Store all artifacts (`inference_data.nc`, `trace.png`, `forest.png`, `posterior_predictive.png`, `pit_ecdf.png`, `summary.csv`, `diagnostics.json`, `calibration.json`) in a slug-named results folder, and produce `report.md` from the canonical template in [references/reporting.md](references/reporting.md). Code without an interpreted, fixed-shape report is incomplete.
+- **Use `scripts/check_diagnostics.py` to interpret diagnostics, not hand-rolled prose.** Pipe the JSON outputs of `diagnose_model.py` (and optionally `calibration_check.py` and `psense_summary`) into `check_diagnostics.py` to get per-section qualitative ratings and an ordered, actionable Suggested Next Steps list. Use those outputs verbatim in the report's Assessment lines; expand only with problem-specific context.
 - **Always use the posterior mean (not median) for predictive probabilities.** The proper Bayesian predictive distribution averages over the posterior: `P(Y=k|x) = (1/S) Σ P(Y=k|x,θₛ)`. This is the mean, not the median. The median does not correspond to the posterior predictive distribution, can violate probability coherence (probabilities may not sum to 1), and biases calibration due to Jensen's inequality. In code: use `np.mean(probs, axis=sample_axis)`, never `np.median(...)`.
 - **Use `pm.set_data()` + `pm.sample_posterior_predictive()` for out-of-sample predictions.** Don't manually extract posterior samples and recompute predictions — let PyMC propagate uncertainty properly. Define predictors as `pm.Data(...)` during model building, then swap in new data:
 
@@ -130,17 +131,20 @@ with model:
 
 ## Utility scripts
 
-Run `diagnose_model.py` after sampling to get a structured convergence + diagnostics report:
+Run these in order — each script's output feeds the next.
 
 ```bash
-python scripts/diagnose_model.py --idata path/to/inference_data.nc
+# 1. Run convergence + LOO + PPC checks (writes diagnostics.json)
+python scripts/diagnose_model.py --idata <slug>/inference_data.nc --output <slug>/diagnostics.json
+
+# 2. Run calibration check (writes calibration.json + pit_ecdf.png + pit_coverage.png)
+python scripts/calibration_check.py --idata <slug>/inference_data.nc --output <slug>/calibration.json --save-plots --plot-dir <slug>/
+
+# 3. Interpret the JSON outputs into qualitative ratings + suggested next steps
+python scripts/check_diagnostics.py --diagnostics <slug>/diagnostics.json --calibration <slug>/calibration.json --output <slug>/check_report.json
 ```
 
-Run `calibration_check.py` to generate calibration plots:
-
-```bash
-python scripts/calibration_check.py --idata path/to/inference_data.nc
-```
+Step 3 is what powers the `report.md` Assessment lines and Suggested Next Steps section — never hand-roll those interpretations from raw R-hat / ESS / pareto-k numbers when the harness can produce them consistently.
 
 See [scripts/](scripts/) for all available utilities.
 
@@ -155,6 +159,8 @@ These are battle-tested lessons that save hours of debugging:
 - **Forgetting to standardize predictors** makes shared priors inappropriate and slows sampling. Always standardize before fitting, then back-transform for interpretation.
 - **Horseshoe priors create a double-funnel geometry** that standard NUTS can struggle with. Always use the **regularized (Finnish) horseshoe** (Piironen & Vehtari, 2017), which adds a slab component that smooths the geometry. Set `target_accept=0.95` or higher. If you see divergences with a horseshoe model, this is almost certainly the cause.
 - **`np.median` on posterior predictive probabilities is a silent bug.** It does not produce the Bayesian predictive distribution and can yield probabilities that don't sum to 1 across categories. Always use `np.mean` over the posterior samples dimension.
+- **Discrete latents: marginalize, don't plug in.** NUTS-only samplers (nutpie, Pathfinder) cannot sample discrete or `ordered` variables at all; PyMC's default `pm.sample()` falls back to a compound Metropolis step for them, which mixes poorly. Prefer to **marginalize** the discrete latents — `pmx.marginalize(model, [...])` or analytic integration — and feed a **true mixture likelihood** downstream (exact, O(K) per observation, NUTS-compatible). Plugging a soft relaxation (soft-min/argmax, or `E[z]`) into a nonlinear function is mathematically wrong: it is not the marginal and can return out-of-bounds values. Any mixture also needs an identification constraint (e.g. `ordered` components) or chains will label-switch.
+- **Overlapping data subsets in a likelihood double-count.** When a likelihood is assembled from per-subset terms, the subsets must partition the data *disjointly* — an observation that lands in two terms is counted twice, silently over-shrinking the posterior. Partition disjointly, or model the overlap explicitly.
 
 ## When things go wrong
 

--- a/bayesian-workflow/references/diagnostics.md
+++ b/bayesian-workflow/references/diagnostics.md
@@ -100,6 +100,20 @@ mu = pm.Deterministic("mu", mu_offset * sigma_group)
 3. **Stronger priors on scale parameters**: Tight prior on group-level SD can eliminate the funnel, especially avoiding the regions near 0, which don't really mean much in practice anyways (if there is no group-level variation, you don't need to model it!)
 4. **Marginalize discrete parameters**: If possible, integrate out discrete variables analytically
 
+## When sampling fails: the escalation ladder
+
+When sampling is broken — persistent divergences, R-hat > 1.01, low ESS, or stuck/separated chains — escalate in this order, **re-checking diagnostics after each rung and stopping at the first that fixes it.** Don't jump to a model rewrite when a sampler setting would do, and don't re-run an unchanged model hoping it converges. (For divergences *specifically*, the targeted fixes above are the first thing to try; the ladder is the general path when problems persist or aren't divergence-specific.)
+
+1. **Raise `target_accept` (→ 0.95, then 0.99).** Smaller steps, fewer divergences. *Check:* divergences fall toward zero — a handful remaining with healthy R-hat/ESS is often acceptable.
+2. **Change the initializer: `init="adapt_diag_grad"`.** A gradient-informed mass-matrix start; helps when early adaptation is the failure. *Check:* chains start in-distribution (no long drift in the rank plots).
+3. **Sample longer: more `tune` and `draws`.** If ESS is the *only* failure (good R-hat, no divergences), the chain simply needs more iterations. *Check:* ESS_bulk and ESS_tail clear 100 × n_chains.
+4. **Pathfinder warm-start (init only).** Run `pmx.fit(method="pathfinder")` to find a good starting point / mass matrix, then use it to initialize NUTS — keep NUTS as the actual sampler (Pathfinder on its own is an approximation). *Check:* faster, in-distribution start; divergences/R-hat improved.
+5. **Non-centered reparameterization.** The funnel fix for hierarchical models (see the divergence list above). *Check:* funnel gone in the pairs plot; divergences cleared.
+6. **Scope down to isolate the problem.** Fit a single group, drop an interaction, or simplify the likelihood to find *which* component breaks sampling. *Check:* the reduced model samples cleanly — if so, the dropped piece is the culprit; add it back deliberately.
+7. **Architectural inversion — rethink the generative structure.** Re-marginalize discrete latents, re-order a mixture for identification, change the likelihood family, or restructure the hierarchy. **Pause and confirm with the user before this rung** — it changes the model's *meaning*, not just its sampling, and that decision is the user's.
+
+If you reach rung 7 without resolution, the problem is usually identifiability, not sampling — consult the identifiability guidance and report the model as not yet trustworthy rather than interpreting a non-converged posterior.
+
 ## Trace plots and rank plots
 
 ```python

--- a/bayesian-workflow/references/reporting.md
+++ b/bayesian-workflow/references/reporting.md
@@ -1,17 +1,222 @@
 # Reporting Bayesian Analyses
 
 ## Contents
+- Canonical report artifact (`<slug>/report.md`)
 - Reporting principles
-- Analysis report template
+- Analysis report template (legacy / inline)
 - Presentation template
 - Visualization standards
 - Common reporting mistakes
+
+## Canonical report artifact
+
+After every full analysis run, generate `report.md` inside a dedicated results folder. Static descriptions are verbatim — copy them as-is. `<placeholders>` are dynamic — fill them in from the actual run.
+
+### Results folder naming
+
+All artifacts for a single analysis go into `<slug>/`, where `<slug>` is a short lowercase-hyphenated descriptor of the analysis (e.g., `churn-logistic`, `school-funding-hierarchical`). Choose the most informative 1–3 word name. When iterating on the same problem, append a version: `churn-logistic-v2/`.
+
+```python
+import os
+
+results_dir = "<slug>"  # e.g., "churn-logistic"
+os.makedirs(results_dir, exist_ok=True)
+```
+
+### Output structure
+
+```
+<slug>/
+├── inference_data.nc            # full InferenceData (idata.to_netcdf)
+├── model_graph.png              # pm.model_to_graphviz output
+├── prior_predictive.png         # az.plot_ppc(..., group="prior")
+├── trace.png                    # az.plot_trace(idata, kind="rank_vlines")
+├── forest.png                   # az.plot_forest of posteriors
+├── posterior_predictive.png     # az.plot_ppc(idata)
+├── pit_ecdf.png                 # azp.plot_ppc_pit (or loo_pit)
+├── pit_coverage.png             # azp.plot_ppc_pit(coverage=True)
+├── psense.png                   # azp.plot_psense_dist (if sensitivity ran)
+├── summary.csv                  # az.summary(idata).to_csv
+├── diagnostics.json             # diagnose_model.py output
+├── calibration.json             # calibration_check.py output
+├── psense.json                  # psense_summary().to_json (if available)
+└── report.md                    # this template, filled in
+```
+
+### Figure naming convention
+
+Save figures using these exact names so the report template can reference them statically:
+
+```python
+import arviz as az
+import matplotlib.pyplot as plt
+
+# Trace
+ax = az.plot_trace(idata, kind="rank_vlines")
+plt.gcf().savefig(os.path.join(results_dir, "trace.png"), dpi=150, bbox_inches="tight")
+plt.close()
+
+# Forest
+ax = az.plot_forest(idata, combined=True)
+plt.gcf().savefig(os.path.join(results_dir, "forest.png"), dpi=150, bbox_inches="tight")
+plt.close()
+
+# Posterior predictive
+ax = az.plot_ppc(idata)
+plt.gcf().savefig(os.path.join(results_dir, "posterior_predictive.png"), dpi=150, bbox_inches="tight")
+plt.close()
+```
+
+For ArviZ 1.0+ calibration plots (`arviz_plots.plot_ppc_pit`), use `pc.savefig(...)` directly — `scripts/calibration_check.py --save-plots --plot-dir <slug>` does this automatically with the right filenames.
+
+### Report template
+
+Copy this template verbatim into `<slug>/report.md` and fill in the `<placeholders>`. Every paragraph that is not a placeholder is **static** — keep it as-is in every report.
+
+Sections marked **[IF …]** are optional — include them only when the relevant analysis ran. Otherwise omit the entire block (header included).
+
+````markdown
+# <Analysis Title> — Bayesian Analysis Report
+
+## Executive Summary
+
+<2–3 sentences summarizing the key finding with credible intervals and the most important caveat. Lead with the substantive conclusion, not the model. If the audience is non-technical, also translate to natural frequencies (e.g., "roughly 9 in 10 chance the effect is positive").>
+
+## Data and Question
+
+| | |
+|---|---|
+| Source | <where the data came from> |
+| Sample size | <N> |
+| Key variables | <comma-separated list with brief descriptions> |
+| Question | <one-sentence statement of what we want to learn> |
+
+<Brief description of any notable features: missingness, outliers, grouping structure, or transformations applied before modeling.>
+
+## Model Specification
+
+![Model graph](model_graph.png)
+
+The model graph shows the directed structure of the generative process. Plates indicate replicated structure (e.g., over observations or groups). Shaded nodes are observed; unshaded nodes are latent parameters or hyperparameters with priors.
+
+**Generative story.** <1–3 sentences in plain language describing the assumed data-generating process. What was sampled first, what depended on what, and what was finally observed?>
+
+| Parameter | Prior | Justification |
+|-----------|-------|---------------|
+| <param_1> | <e.g., Normal(0, 2.5)> | <e.g., Weakly informative on standardized predictors> |
+| <param_2> | <prior> | <justification> |
+
+## Prior Predictive Check
+
+![Prior predictive](prior_predictive.png)
+
+The prior predictive distribution shows the data the model would generate before seeing any observations, using only the priors. Plausible Bayesian models produce prior predictive samples that span — but do not wildly exceed — the range of the observed data. Tightly bunched priors that exclude the observed range indicate priors that are too narrow; priors that produce wildly implausible values (e.g., negative blood pressure, billion-dollar daily revenue) indicate priors that are too wide and should be tightened before sampling.
+
+**Assessment:** <1–3 sentences — do prior predictive samples span the plausible range of the data? Any signs of over-tight or over-wide priors? If priors were revised after this check, note that here.>
+
+## Sampling and Convergence
+
+| Diagnostic | Value | Threshold | Status |
+|------------|-------|-----------|--------|
+| Max R-hat | <e.g., 1.003> | ≤ 1.01 | <✓ / ✗> |
+| Min ESS (bulk) | <e.g., 1840> | ≥ 100 × n_chains | <✓ / ✗> |
+| Min ESS (tail) | <e.g., 1620> | ≥ 100 × n_chains | <✓ / ✗> |
+| Divergences | <e.g., 0> | 0 (or near zero) | <✓ / ✗> |
+
+![Trace](trace.png)
+
+Rank-vline trace plots check chain mixing. Well-mixed chains show overlapping rank distributions across chains — the vertical lines (one per chain) sit close to the uniform expectation. Visible separation between chains, monotone drift, or stuck chains indicate non-convergence and the posterior should not be interpreted.
+
+**Assessment:** <1–2 sentences from `check_diagnostics()` convergence section — state whether all diagnostics pass and flag any parameters with R-hat > 1.01, ESS < threshold, or divergences concentrated in their posterior.>
+
+## Posterior
+
+![Forest](forest.png)
+
+The forest plot shows posterior medians (points) and credible intervals (lines) for the parameters of interest. Wide intervals indicate parameters the data are only weakly informative for; narrow intervals concentrated away from zero indicate strong evidence in a direction.
+
+| Parameter | Mean | SD | 94% HDI | P(>0) |
+|-----------|------|----|---------|-------|
+| <param_1> | <m> | <s> | [<lo>, <hi>] | <prob> |
+| <param_2> | <m> | <s> | [<lo>, <hi>] | <prob> |
+
+**Substantive interpretation.** <2–4 sentences on what the posteriors mean in domain terms — effect sizes in original units, practical significance, what the posterior probability of direction implies for the question. Avoid frequentist language ("significant", "rejected").>
+
+## Posterior Predictive Check
+
+![Posterior predictive](posterior_predictive.png)
+
+The posterior predictive distribution shows what the fitted model implies the data should look like. A well-fitting model produces replicated samples that closely overlap the observed data across the full range. Systematic discrepancies — the model under-predicts the tails, misses a mode, or over-disperses — indicate model misspecification and should be addressed before drawing conclusions.
+
+**Assessment:** <1–3 sentences — does the posterior predictive cover the observed data? Any systematic miss (under-dispersed, missing tails, missing modes)? If misspecification is visible, state which aspect of the data the model fails to reproduce.>
+
+## Calibration
+
+![PIT ECDF](pit_ecdf.png)
+
+The PIT-ECDF plot tests whether the model's predictive distribution is calibrated — that is, whether stated credible levels match empirical coverage. The empirical CDF of probability integral transform values should fall within the simultaneous confidence bands. Lines outside the bands above the diagonal indicate under-confident predictions (intervals wider than they should be); lines below indicate over-confident predictions (intervals too narrow).
+
+![Coverage](pit_coverage.png)
+
+The coverage plot tests the same idea in coverage units: it asks whether nominal central credible intervals (50%, 80%, 95%) actually contain the stated fraction of the observed data. A well-calibrated model lies on the diagonal.
+
+**Assessment:** <1–2 sentences from `check_diagnostics()` calibration section — well-calibrated, over-confident, or under-confident, with the mean coverage deviation if available.>
+
+## [IF MODEL_COMPARISON] Model Comparison
+
+| Model | ELPD | SE | ΔELPD | Weight |
+|-------|------|----|-------|--------|
+| <model_a> | <elpd> | <se> | <delta> | <weight> |
+| <model_b> | <elpd> | <se> | <delta> | <weight> |
+
+**Assessment:** <1–3 sentences — which model is preferred, by how much, and whether the preference is robust (ΔELPD > 2 × SE) or marginal.>
+
+## [IF SENSITIVITY] Prior Sensitivity
+
+![Prior sensitivity](psense.png)
+
+| Parameter | Prior CJS | Likelihood CJS | Diagnostic |
+|-----------|-----------|----------------|------------|
+| <param_1> | <c> | <c> | <Low / Strong prior — justified by …> |
+
+**Assessment:** <1–3 sentences — which parameters are sensitive to prior choice, whether the substantive conclusions depend on those priors, and whether informative priors that flag as sensitive are explicitly justified.>
+
+## Limitations and Threats
+
+This section is mandatory. Rank threats by severity. For each: state the assumption that might be violated, the direction of bias if violated, and what additional data or design would resolve the threat.
+
+1. <threat 1>
+2. <threat 2>
+
+## Suggested Next Steps
+
+<Provide 1–5 concrete, actionable steps. Use the output of `scripts/check_diagnostics.py` `suggest_next_steps()` as the starting point; expand with problem-specific context. Don't dump generic advice — tailor it to what this run actually showed.>
+
+1. <step>
+2. <step>
+
+## Appendix
+
+<Full ArviZ summary table from `summary.csv`. Code repository link. Random seed used. Software versions (PyMC, ArviZ, nutpie).>
+````
+
+### Common "Suggested Next Steps" patterns
+
+Use these as a reference when filling in the final section. The harness in `scripts/check_diagnostics.py` emits these automatically based on what it finds — only override when problem-specific context warrants it.
+
+- All diagnostics healthy, calibration good → "Proceed to interpretation. If decision-stakes warrant, run prior sensitivity (`psense_summary`) and report alongside results."
+- Divergences concentrated near a boundary parameter → "Reparameterize the affected parameter as non-centered, or replace `HalfCauchy` with `Gamma(2, …)` for scale priors."
+- High R-hat with bimodal trace → "Run more draws and use `init=\"adapt_diag_grad\"`; consider whether the posterior is genuinely multimodal (label-switching, ordering identifiability)."
+- Poor PIT calibration with good convergence → "Likelihood is misspecified — consider StudentT for heavy tails, NegBinomial for overdispersed counts, or hierarchical structure for grouped variation."
+- LOO Pareto k > 0.7 for some observations → "Investigate the influential points (often outliers or leverage). Consider a more robust likelihood or refit excluding the worst points to test sensitivity."
+- Strong prior sensitivity on a parameter → "Either justify the informative prior with domain knowledge, or widen the prior and refit. Report both runs if the substantive conclusion changes."
+- Posterior shows non-identifiability (parameters perfectly correlated) → "Either combine the components or restructure data so they're separately identified — see `references/diagnostics.md` on identifiability."
 
 ## Reporting principles
 
 Bayesian results are inherently richer than frequentist results -- use that richness.
 
-1. **Report full posteriors**, not just point estimates. Use HDI (Highest Density Interval) as default, 94% unless context demands otherwise (94% avoids the false precision of 95% and conveys its arbitrary nature).
+1. **Report full posteriors**, not just point estimates, with the HDI (Highest Density Interval) as the default summary. **No interval width is magic — 95% least of all.** Choose the width from the decision context rather than convention, and report several when it matters (e.g. a 50% interval for the typical case alongside 89%/94% for a robust range). The default 94% is deliberately off-95 to signal that the number is a *choice*, not a law of nature; a wider interval isn't "more rigorous," it just trades a tighter claim for more coverage.
 2. **Visualize uncertainty**. Every parameter estimate should have a visual representation of its posterior.
 3. **Show the model**. Include a model specification section -- readers should know exactly what was assumed. Use `pm.model_to_graphviz` to visualize the model.
 4. **Report diagnostics**. Convergence and model criticism results build trust.

--- a/bayesian-workflow/scripts/calibration_check.py
+++ b/bayesian-workflow/scripts/calibration_check.py
@@ -126,7 +126,10 @@ def save_pit_plot(
     confidence bands (Säilynoja et al. 2022).
     """
     plot_fn = azp.plot_loo_pit if use_loo else azp.plot_ppc_pit
-    pc = plot_fn(dt, var_names=var_name, coverage=coverage, ci_prob=ci_prob)
+    # arviz_plots 1.0 names the simultaneous-band probability `envelope_prob`;
+    # passing `ci_prob` here falls through to **pc_kwargs and the backend rejects
+    # it ("no active aesthetic"). The lower-level ecdf helpers still use ci_prob.
+    pc = plot_fn(dt, var_names=var_name, coverage=coverage, envelope_prob=ci_prob)
     pc.savefig(output_path)
     return output_path
 

--- a/bayesian-workflow/scripts/check_diagnostics.py
+++ b/bayesian-workflow/scripts/check_diagnostics.py
@@ -1,0 +1,441 @@
+"""
+Interpret Bayesian model diagnostics and suggest next steps.
+
+Reads structured outputs from ``diagnose_model.py`` and ``calibration_check.py``
+and produces qualitative per-section assessments for the diagnostic report,
+plus an ordered list of suggested next steps.
+
+This script does not re-run diagnostics — it interprets what is already there.
+Run ``diagnose_model.py`` and ``calibration_check.py`` first to produce the JSON
+inputs, then this script to turn the numbers into human-readable ratings and
+actionable recommendations.
+
+Usage:
+    python check_diagnostics.py --diagnostics diagnostics.json
+    python check_diagnostics.py --diagnostics diagnostics.json --calibration calibration.json
+    python check_diagnostics.py --diagnostics diagnostics.json --psense psense.json --output report.json
+
+The ``diagnostics.json`` is the output of ``diagnose_model.py``.
+The ``calibration.json`` is the output of ``calibration_check.py``.
+The ``psense.json`` (optional) is a JSON dump of ``psense_summary(idata)``.
+"""
+
+import argparse
+import json
+import sys
+
+
+# House thresholds — internal reference levels for qualitative interpretation.
+# These are NOT exposed in reports — use the qualitative labels instead.
+RHAT_OK = 1.01
+DIVERGENCE_OK = 0
+DIVERGENCE_FAIR = 0.005  # < 0.5% of post-warmup draws
+PARETO_K_OK = 0.5
+PARETO_K_FAIR = 0.7
+COVERAGE_DEVIATION_OK = 0.02
+COVERAGE_DEVIATION_FAIR = 0.05
+PSENSE_OK = 0.05
+PSENSE_FAIR = 0.10
+
+
+def _rate_convergence(conv: dict) -> tuple[str, list[str]]:
+    """Return (rating, problematic_param_names) for the convergence section.
+
+    Consumes the unified schema emitted by ``diagnose_model.check_convergence``
+    — both the ``arviz_stats.diagnose`` and manual fallback paths share it, so
+    real parameter names flow through (no opaque placeholder).
+    """
+    if not conv or conv.get("all_ok"):
+        return "excellent", []
+
+    issues: list[str] = []
+
+    rhat = conv.get("rhat", {})
+    ess_b = conv.get("ess_bulk", {})
+    ess_t = conv.get("ess_tail", {})
+    div = conv.get("divergences", {})
+    bfmi = conv.get("bfmi", {})
+    td = conv.get("treedepth", {})
+
+    if not rhat.get("ok", True):
+        issues.extend(rhat.get("problematic_params", []))
+    if not ess_b.get("ok", True):
+        issues.extend(ess_b.get("problematic_params", []))
+    if not ess_t.get("ok", True):
+        issues.extend(ess_t.get("problematic_params", []))
+    if not div.get("ok", True):
+        issues.append(f"divergences={div.get('count', 0)}")
+    if not bfmi.get("ok", True):
+        issues.append("low E-BFMI")
+    if not td.get("ok", True):
+        issues.append("max treedepth saturation")
+
+    issues = list(dict.fromkeys(issues))  # dedupe, preserve order
+
+    n_div = div.get("count", 0) if div else 0
+    div_pct = div.get("pct", 0.0) if div else 0.0
+    rhat_max = rhat.get("max") if rhat else None
+
+    if n_div > 0 and div_pct > DIVERGENCE_FAIR * 100:
+        rating = "poor"
+    elif rhat_max is not None and rhat_max > 1.05:
+        rating = "poor"
+    elif issues:
+        rating = "fair"
+    else:
+        rating = "good"
+
+    return rating, issues
+
+
+def _rate_loo(loo: dict) -> str:
+    """Return a qualitative rating for the LOO Pareto-k diagnostic."""
+    if not loo or not loo.get("computed"):
+        return "not computed"
+
+    pk = loo.get("pareto_k", {})
+    n_bad = pk.get("n_bad", 0)
+    n_marginal = pk.get("n_marginal", 0)
+    pk_max = pk.get("max", 0.0)
+
+    if pk_max <= PARETO_K_OK:
+        return "excellent"
+    elif pk_max <= PARETO_K_FAIR and n_bad == 0:
+        return "fair"
+    elif n_bad > 0:
+        return "poor"
+    else:
+        return "fair"
+
+
+def _rate_calibration(cal: dict) -> tuple[str, str]:
+    """Return (rating, diagnosis) for calibration."""
+    if not cal:
+        return "not computed", ""
+
+    assessment = cal.get("assessment", {})
+    diagnosis = assessment.get("calibration_diagnosis", "")
+    well_cal = assessment.get("well_calibrated", False)
+    mean_dev = abs(assessment.get("mean_coverage_deviation", 0.0))
+
+    if well_cal:
+        return "excellent", diagnosis
+    if mean_dev <= COVERAGE_DEVIATION_FAIR:
+        return "fair", diagnosis
+    return "poor", diagnosis
+
+
+def _rate_psense(ps: dict) -> tuple[str, list[str]]:
+    """Return (rating, flagged_params) for prior sensitivity."""
+    if not ps:
+        return "not computed", []
+
+    # Expected: dict of {param: {"prior": <cjs>, "likelihood": <cjs>}}
+    flagged: list[str] = []
+    max_prior_cjs = 0.0
+
+    for param, vals in ps.items():
+        if isinstance(vals, dict):
+            prior = float(vals.get("prior", 0.0))
+            max_prior_cjs = max(max_prior_cjs, prior)
+            if prior > PSENSE_FAIR:
+                flagged.append(param)
+
+    if max_prior_cjs <= PSENSE_OK:
+        return "low sensitivity", flagged
+    if max_prior_cjs <= PSENSE_FAIR:
+        return "moderate sensitivity", flagged
+    return "strong sensitivity", flagged
+
+
+def check_diagnostics(
+    diagnostics: dict | None = None,
+    calibration: dict | None = None,
+    psense: dict | None = None,
+) -> dict:
+    """Interpret diagnostic JSON outputs into qualitative assessments.
+
+    Parameters
+    ----------
+    diagnostics : dict, optional
+        Output of ``diagnose_model.generate_report()``. Provides
+        ``convergence``, ``loo``, and ``posterior_predictive`` sub-reports.
+    calibration : dict, optional
+        Output of ``calibration_check.py``.
+    psense : dict, optional
+        Output of ``psense_summary(idata).to_dict()`` or equivalent.
+
+    Returns
+    -------
+    dict
+        Structured assessment with sections: ``convergence``, ``loo``,
+        ``calibration``, ``psense``, plus ``summary`` (one-line per section).
+    """
+    report: dict = {}
+
+    if diagnostics is not None:
+        conv_rating, conv_issues = _rate_convergence(diagnostics.get("convergence", {}))
+        report["convergence"] = {
+            "rating": conv_rating,
+            "problematic_params": conv_issues,
+        }
+        report["loo"] = {"rating": _rate_loo(diagnostics.get("loo", {}))}
+        ppc = diagnostics.get("posterior_predictive", {})
+        report["posterior_predictive"] = {
+            "available": bool(ppc.get("available", False)),
+        }
+
+    if calibration is not None:
+        cal_rating, cal_diagnosis = _rate_calibration(calibration)
+        report["calibration"] = {
+            "rating": cal_rating,
+            "diagnosis": cal_diagnosis,
+        }
+
+    if psense is not None:
+        ps_rating, ps_flagged = _rate_psense(psense)
+        report["psense"] = {
+            "rating": ps_rating,
+            "flagged_params": ps_flagged,
+        }
+
+    report["summary"] = _build_summary(report)
+    return report
+
+
+def _build_summary(report: dict) -> dict:
+    """One short sentence per section, suitable for the report's Assessment lines."""
+    s: dict = {}
+
+    if "convergence" in report:
+        r = report["convergence"]
+        if r["rating"] == "excellent":
+            s["convergence"] = "All convergence diagnostics passed (R-hat ≤ 1.01, ESS adequate, no divergences)."
+        elif r["rating"] == "good":
+            s["convergence"] = "Convergence diagnostics broadly pass; minor flags worth noting."
+        elif r["rating"] == "fair":
+            params = ", ".join(r["problematic_params"][:3]) or "some parameters"
+            s["convergence"] = f"Convergence is fair — flags on {params}. Inspect before trusting the posterior."
+        else:
+            params = ", ".join(r["problematic_params"][:3]) or "multiple parameters"
+            s["convergence"] = f"Poor convergence on {params}. Posterior should not be interpreted until resolved."
+
+    if "loo" in report:
+        s["loo"] = f"LOO Pareto-k: {report['loo']['rating']}."
+
+    if "calibration" in report:
+        r = report["calibration"]
+        diag = r.get("diagnosis", "")
+        s["calibration"] = (
+            f"Calibration is {r['rating']}" + (f" — {diag}." if diag else ".")
+        )
+
+    if "psense" in report:
+        r = report["psense"]
+        flagged = ", ".join(r["flagged_params"]) if r["flagged_params"] else "none"
+        s["psense"] = f"Prior sensitivity: {r['rating']} (flagged: {flagged})."
+
+    return s
+
+
+def suggest_next_steps(report: dict) -> list[str]:
+    """Combine the interpreted report into an ordered, actionable list.
+
+    Most-critical issues first. Returns generic guidance — extend with
+    problem-specific context when filling in the report.
+    """
+    steps: list[str] = []
+
+    # ── Convergence (highest priority) ────────────────────────────────
+    conv = report.get("convergence", {})
+    if conv.get("rating") in ("poor", "fair"):
+        params = conv.get("problematic_params", [])
+        has_divergences = any("divergence" in str(p).lower() for p in params)
+        # Non-parameter flags (divergences, E-BFMI, treedepth) are surfaced
+        # separately — keep them out of the per-parameter R-hat/ESS message so
+        # it never interpolates a flag phrase where a parameter name belongs.
+        _non_param = ("divergence", "e-bfmi", "treedepth", "=")
+        named_params = [
+            p for p in params if not any(tok in str(p).lower() for tok in _non_param)
+        ]
+
+        if has_divergences:
+            steps.append(
+                "Divergences detected — reparameterize the affected component "
+                "(non-centered for hierarchical scales; replace HalfCauchy with "
+                "Gamma(2, ...) for scale priors) and increase target_accept to 0.95–0.99."
+            )
+        if named_params:
+            preview = ", ".join(named_params[:3])
+            steps.append(
+                f"R-hat or ESS flags on {preview} — run more draws, try "
+                "init=\"adapt_diag_grad\", or warm-start with `pmx.fit(method=\"pathfinder\")`. "
+                "Check for multimodality with az.plot_trace(idata, kind=\"rank_vlines\")."
+            )
+
+    # ── Calibration ───────────────────────────────────────────────────
+    cal = report.get("calibration", {})
+    if cal.get("rating") == "poor":
+        diag = cal.get("diagnosis", "")
+        if "over-confident" in diag:
+            steps.append(
+                "Calibration is over-confident — likelihood is too narrow for the "
+                "data. Consider StudentT for continuous outcomes with heavy tails, "
+                "NegBinomial for overdispersed counts, or hierarchical structure if "
+                "groups have distinct variance."
+            )
+        elif "under-confident" in diag:
+            steps.append(
+                "Calibration is under-confident — predictions are too uncertain. "
+                "Tighten priors that are dominating the likelihood, or check whether "
+                "the model is overcomplicated for the data."
+            )
+        else:
+            steps.append(
+                "Calibration check failed — re-examine the likelihood and the "
+                "prior predictive range before interpreting posteriors."
+            )
+    elif cal.get("rating") == "fair":
+        steps.append(
+            "Calibration is fair but not excellent — consider tightening priors, "
+            "switching to a heavier-tailed likelihood, or running a sensitivity "
+            "check on the most informative observations."
+        )
+
+    # ── LOO ───────────────────────────────────────────────────────────
+    loo_rating = report.get("loo", {}).get("rating", "not computed")
+    if loo_rating == "poor":
+        steps.append(
+            "LOO Pareto-k > 0.7 for some observations — these points are highly "
+            "influential. Inspect them (often outliers or high-leverage), consider "
+            "a more robust likelihood (StudentT), or refit excluding them to test "
+            "sensitivity. Use az.loo(idata, pointwise=True) and az.plot_khat(loo)."
+        )
+    elif loo_rating == "fair":
+        steps.append(
+            "LOO Pareto-k between 0.5 and 0.7 for some observations — borderline. "
+            "Identify the points and decide whether they're substantively important; "
+            "consider a robust likelihood if they reflect a tail-heavy data process."
+        )
+
+    # ── PPC availability ──────────────────────────────────────────────
+    if not report.get("posterior_predictive", {}).get("available", True):
+        steps.append(
+            "No posterior_predictive group found — run "
+            "`pm.sample_posterior_predictive(idata)` and re-run diagnostics. "
+            "Models without PPC cannot be model-criticized."
+        )
+
+    # ── Prior sensitivity ─────────────────────────────────────────────
+    ps = report.get("psense", {})
+    if ps.get("rating") == "strong sensitivity":
+        flagged = ", ".join(ps.get("flagged_params", []))
+        steps.append(
+            f"Strong prior sensitivity on {flagged} — either justify the "
+            "informative prior explicitly with domain knowledge, or widen it "
+            "and refit. Report both versions if the substantive conclusion changes."
+        )
+    elif ps.get("rating") == "moderate sensitivity":
+        flagged = ", ".join(ps.get("flagged_params", []))
+        steps.append(
+            f"Moderate prior sensitivity on {flagged} — note in the report. "
+            "Conclusions for those parameters depend partly on the prior."
+        )
+
+    # ── Default if nothing is wrong ───────────────────────────────────
+    if not steps:
+        steps.append(
+            "All diagnostics are within acceptable bounds — proceed to "
+            "interpretation. Translate posteriors into decision-relevant terms "
+            "and document the model assumptions in the report."
+        )
+        if report.get("psense", {}).get("rating") == "not computed":
+            steps.append(
+                "Consider running prior sensitivity (`psense_summary(idata)`) "
+                "before publication, especially if any conclusions are policy-relevant."
+            )
+
+    return steps
+
+
+def _load_optional(path: str | None) -> dict | None:
+    if path is None:
+        return None
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except FileNotFoundError:
+        print(f"Warning: {path} not found — skipping.", file=sys.stderr)
+        return None
+    except json.JSONDecodeError as e:
+        print(f"Warning: could not parse {path} ({e}) — skipping.", file=sys.stderr)
+        return None
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Interpret Bayesian diagnostics and suggest next steps"
+    )
+    parser.add_argument(
+        "--diagnostics",
+        required=True,
+        help="Path to diagnostics JSON (output of diagnose_model.py)",
+    )
+    parser.add_argument(
+        "--calibration",
+        default=None,
+        help="Path to calibration JSON (output of calibration_check.py)",
+    )
+    parser.add_argument(
+        "--psense",
+        default=None,
+        help="Path to prior sensitivity JSON (psense_summary output)",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Path to save full JSON report (default: print to stdout)",
+    )
+    args = parser.parse_args()
+
+    diagnostics = _load_optional(args.diagnostics)
+    if diagnostics is None:
+        print(
+            json.dumps(
+                {"error": f"Could not load required diagnostics file: {args.diagnostics}"}
+            )
+        )
+        sys.exit(1)
+
+    calibration = _load_optional(args.calibration)
+    psense = _load_optional(args.psense)
+
+    report = check_diagnostics(
+        diagnostics=diagnostics,
+        calibration=calibration,
+        psense=psense,
+    )
+    next_steps = suggest_next_steps(report)
+    report["next_steps"] = next_steps
+
+    print("=== Per-Section Assessment ===")
+    for section, line in report.get("summary", {}).items():
+        print(f"  {section}: {line}")
+    print("==============================\n")
+
+    print("=== Suggested Next Steps ===")
+    for i, step in enumerate(next_steps, 1):
+        print(f"  {i}. {step}")
+    print("============================\n")
+
+    output = json.dumps(report, indent=2)
+    if args.output:
+        with open(args.output, "w") as f:
+            f.write(output)
+        print(f"Report saved to {args.output}")
+    else:
+        print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/bayesian-workflow/scripts/diagnose_model.py
+++ b/bayesian-workflow/scripts/diagnose_model.py
@@ -29,18 +29,85 @@ except ImportError:
     HAS_DIAGNOSE = False
 
 
+def _json_default(o):
+    """Coerce stray numpy scalars/arrays so json.dumps never chokes.
+
+    Belt-and-suspenders: check_convergence already returns primitives, but LOO
+    and any future additions may carry numpy types. np.int64 in particular is
+    not a Python int and is rejected by the default JSON encoder.
+    """
+    if isinstance(o, np.integer):
+        return int(o)
+    if isinstance(o, np.floating):
+        return float(o)
+    if isinstance(o, np.ndarray):
+        return o.tolist()
+    return str(o)
+
+
+def _max_from_dataset(ds):
+    """Best-effort scalar maximum from an xarray Dataset of diagnostic values.
+
+    ``arviz_stats.diagnose`` returns the per-parameter R-hat values as an xarray
+    Dataset (not JSON-serializable). We only need the scalar max for rating, so
+    extract it defensively and drop the Dataset itself.
+    """
+    if ds is None:
+        return None
+    try:
+        return float(ds.to_array().max())
+    except Exception:
+        return None
+
+
 def check_convergence(idata):
-    """Run all convergence diagnostics. Returns structured results."""
+    """Run all convergence diagnostics. Returns structured results.
+
+    Both code paths emit the SAME serializable schema so ``check_diagnostics.py``
+    has a single contract to consume: ``rhat`` / ``ess_bulk`` / ``ess_tail`` /
+    ``divergences`` each carry ``ok`` and ``problematic_params``; the
+    ``arviz_stats.diagnose`` path additionally reports ``bfmi`` and ``treedepth``.
+    No numpy scalars, numpy arrays, or xarray objects leak into the dict — those
+    are not JSON-serializable and would crash the report writer.
+    """
     # Use arviz_stats.diagnose() if available — it covers R-hat, ESS,
     # divergences, tree depth saturation, and E-BFMI in one call.
     if HAS_DIAGNOSE:
-        has_errors, diagnostics = azs.diagnose(
-            idata, return_diagnostics=True, show_diagnostics=True
+        # show_diagnostics=False keeps stdout clean so the JSON report can be
+        # piped there when --output is omitted.
+        has_errors, d = azs.diagnose(
+            idata, return_diagnostics=True, show_diagnostics=False
         )
+        rhat_bad = [str(p) for p in d.get("rhat", {}).get("bad_params", [])]
+        ess_bad = [str(p) for p in d.get("ess", {}).get("bad_params", [])]
+        div = d.get("divergent", {})
+        n_div = int(div.get("n_divergent", 0))
+        td = d.get("treedepth", {})
+        n_td = int(td.get("n_max", 0))
+        failed_chains = [int(c) for c in d.get("bfmi", {}).get("failed_chains", [])]
         return {
             "all_ok": not has_errors,
-            "diagnostics": diagnostics,
             "method": "arviz_stats.diagnose",
+            "rhat": {
+                "ok": len(rhat_bad) == 0,
+                "max": _max_from_dataset(d.get("rhat", {}).get("rhat_values")),
+                "problematic_params": rhat_bad,
+            },
+            # diagnose() reports a single ESS check; mirror it into bulk/tail so
+            # the downstream schema matches the manual fallback path exactly.
+            "ess_bulk": {"ok": len(ess_bad) == 0, "problematic_params": ess_bad},
+            "ess_tail": {"ok": len(ess_bad) == 0, "problematic_params": ess_bad},
+            "divergences": {
+                "count": n_div,
+                "pct": round(float(div.get("pct", 0.0)), 2),
+                "ok": n_div == 0,
+            },
+            "treedepth": {
+                "ok": n_td == 0,
+                "n_max": n_td,
+                "pct": round(float(td.get("pct", 0.0)), 2),
+            },
+            "bfmi": {"ok": len(failed_chains) == 0, "failed_chains": failed_chains},
         }
 
     # Fallback for arviz-stats < 1.0.0
@@ -187,7 +254,7 @@ def main():
 
     report = generate_report(idata)
 
-    output = json.dumps(report, indent=2)
+    output = json.dumps(report, indent=2, default=_json_default)
     if args.output:
         with open(args.output, "w") as f:
             f.write(output)

--- a/causal-inference/README.md
+++ b/causal-inference/README.md
@@ -17,9 +17,9 @@ Guides your coding agent through the full causal inference workflow, enforcing D
 5. **Estimate** — Build and fit the model (delegates PyMC mechanics to bayesian-workflow)
 6. **Refute** — Mandatory design-specific robustness checks (placebo tests, sensitivity analysis, falsification)
 7. **Interpret** — Effect size + decision-relevant HDIs + probability of direction
-8. **Report** — Defensible causal language with assumption-first structure
+8. **Report** — Canonical `<treatment>-on-<outcome>/report.md` artifact with programmatic causal-language calibration
 
-The skill enforces guardrails that agents won't apply on their own: no estimation without a confirmed DAG, no causal claims without refutation, assumptions stated before results, and automatic downgrading of causal language when warranted.
+The skill enforces guardrails that agents won't apply on their own: no estimation without a confirmed DAG, adjustment licensed by the DAG rather than timing (pre-treatment covariates are necessary, not sufficient — M-bias still bites), no causal claims without refutation, assumptions stated before results, and a programmatic harness (`scripts/check_refutation.py`) that calibrates the report's causal language — causal / suggestive / associational / descriptive — directly from refutation outcomes, instead of leaving the call to human (or agent) judgment.
 
 ## Install
 
@@ -79,12 +79,14 @@ Once installed, just ask your agent naturally:
 ```
 causal-inference/
 ├── SKILL.md                          # Main workflow instructions
-└── references/
-    ├── dags-and-identification.md    # DAG construction, backdoor/front-door criteria
-    ├── quasi-experiments.md          # DiD, synthetic control, ITS, RDD, IV, IPSW
-    ├── structural-models.md          # pm.do(), pm.observe(), counterfactuals
-    ├── refutation.md                 # Design-specific robustness checks
-    └── reporting.md                  # Causal language guardrails, report templates
+├── references/
+│   ├── dags-and-identification.md    # DAG construction, backdoor/front-door criteria
+│   ├── quasi-experiments.md          # DiD, synthetic control, ITS, RDD, IV, IPSW
+│   ├── structural-models.md          # pm.do(), pm.observe(), counterfactuals
+│   ├── refutation.md                 # Design-specific robustness checks
+│   └── reporting.md                  # Canonical report artifact + causal language guardrails
+└── scripts/
+    └── check_refutation.py           # Interprets refutation outcomes → calibrated causal language + suggested next steps
 ```
 
 ## License

--- a/causal-inference/SKILL.md
+++ b/causal-inference/SKILL.md
@@ -13,7 +13,7 @@ description: >
 license: MIT
 metadata:
   author: "[Alexandre Andorra](https://alexandorra.github.io/)"
-  version: "1.0"
+  version: "1.2"
 ---
 
 # Causal Inference
@@ -51,9 +51,17 @@ are the doing phase. Think before you do.
 5. **Estimate** — Build and fit the model. Delegate all PyMC mechanics to bayesian-workflow skill.
 6. **Refute** — MANDATORY. Run design-specific robustness checks. See [references/refutation.md](references/refutation.md)
 7. **Interpret** — Effect size + decision-relevant HDIs + probability of direction.
-8. **Report** — Generate causal analysis report. See [references/reporting.md](references/reporting.md)
+8. **Report** — Generate `<treatment>-on-<outcome>/report.md` using the canonical template in [references/reporting.md](references/reporting.md). Run `scripts/check_refutation.py` to turn refutation outcomes into pass/marginal/fail ratings, calibrated causal language (causal / suggestive / associational / descriptive), and an ordered next-steps list. Use that output to fill the report's section 7 (causal language calibration) and Suggested Next Steps.
 
 ## Design selection guide
+
+Before reading the table, walk the **intake** — it routes you to a design *and* surfaces the assumptions you'll have to defend later:
+
+1. **Restate the estimand.** ATE, ATT, LATE, or a CATE? On whom, over what period? If you can't write the one-sentence estimand, you don't have a causal question yet — you have a dataset.
+2. **Identify the data shape.** Single time series, wide panel of units, long unit–time panel, cross-section, or pre/post group data?
+3. **Identify the treatment assignment.** Known intervention time, staggered adoption, a threshold/cutoff, a kink, an instrument, or observed treatment with confounders?
+4. **State the identifying story.** What makes the comparison causal — parallel trends, no anticipation, no manipulation at the cutoff, a valid instrument, overlap/positivity, donor support? This is exactly what you'll refute later.
+5. **Recommend one primary design + alternatives — and reconcile with the estimand.** Name the best-fit design from the table plus any plausible cross-check. Then check that the estimand from step 1 is the one the design *actually identifies*: DiD → ATT (on the treated); RDD → a *local* effect at the cutoff; IV → LATE for compliers (under monotonicity); SC → the treated-unit effect. If they differ, change the design or re-scope the estimand and say so. If two designs agree later, that's convergent evidence rather than reliance on a single identification.
 
 | Design | Use when | Key assumption | Tool |
 |---|---|---|---|
@@ -72,6 +80,20 @@ are the doing phase. Think before you do.
 - **No estimation without a confirmed DAG.** A causal graph is not optional decoration — it makes
   assumptions explicit and determines the adjustment set. If the user resists, explain why the DAG
   is non-negotiable before proceeding.
+- **The DAG licenses adjustment, not timing — pre-treatment is necessary, not sufficient.** Pre-treatment
+  timing only rules out two *post*-treatment hazards: collider bias (conditioning on a common effect of
+  treatment and outcome) and over-control (conditioning on a mediator). It does **not** by itself make a
+  variable safe to adjust for. A *pre-treatment* variable can still be a collider on a back-door path —
+  **M-bias**: a common effect of an unobserved cause of treatment and an unobserved cause of the outcome —
+  and adjusting for it *induces* confounding that wasn't there. So include a covariate only if (a) it is
+  pre-treatment **and** (b) the DAG shows it blocks a back-door path and is not itself a collider (or a
+  descendant of one) on an otherwise-blocked path — i.e. it satisfies the back-door/adjustment criterion.
+  Timing is the quick screen; the graph is the authority. (Deliberate **mediation analysis** is the
+  principled exception to the post-treatment ban: it conditions on a post-treatment mediator on purpose to
+  estimate a *different* estimand — direct vs. indirect effects — under stronger assumptions, including
+  **no treatment-induced mediator–outcome confounding**; declare it as mediation, don't slip it in as
+  confounder control.) If the covariates that actually satisfy the back-door criterion are too thin to
+  identify the effect, say so and frame the result as **descriptive, not causal**.
 - **No causal claims without refutation.** Every design has failure modes. Run at minimum one
   design-specific robustness check (placebo test, sensitivity analysis, falsification test) before
   reporting results. See [references/refutation.md](references/refutation.md).
@@ -85,6 +107,16 @@ are the doing phase. Think before you do.
 - **Downgrade causal language when warranted.** If identification assumptions are unverifiable or
   refutation raises flags, soften claims: "consistent with a causal effect" not "causes", "estimated
   effect" not "true effect". Flag uncertainty loudly in the report.
+- **Use `scripts/check_refutation.py` to calibrate language, not human judgment.** The script takes
+  a structured `refutation.json` (see its docstring for schema) and returns a calibrated level —
+  causal / suggestive / associational / descriptive — plus an ordered list of next steps. Use the
+  script's output verbatim in the report; expand only with problem-specific context. Hand-rolled
+  language calibration is exactly where overclaiming creeps in.
+- **Always generate `<treatment>-on-<outcome>/report.md` after the analysis.** Store all artifacts
+  (`inference_data.nc`, `dag.png`, `effect_posterior.png`, `forest.png`, design-specific figures,
+  `refutation.json`, `effect_summary.csv`) in the slug-named results folder, and produce `report.md`
+  from the canonical template in [references/reporting.md](references/reporting.md). The report is
+  the audit trail; code without an interpreted, fixed-shape report is incomplete.
 - **Ask the user when domain knowledge is needed.** You cannot know whether an instrument is valid,
   whether parallel trends holds, or whether a confounder exists without domain expertise. Ask
   before assuming.
@@ -113,6 +145,17 @@ These are battle-tested lessons that save hours of debugging:
   approximate its counterfactual. Check this before running — if violated, the design is invalid.
 - **DiD group variable must be dummy-coded (0/1).** CausalPy rejects string labels like "treatment"/"control". Use integers: 1 = treatment, 0 = control. Data also requires a `unit` column.
 - **SyntheticControl expects wide-format data.** Index = time, columns = unit names, values = outcome. If your data is long format, pivot first: `df.pivot(index="date", columns="unit", values="outcome")`.
+
+## Utility scripts
+
+```bash
+# Interpret refutation outcomes and calibrate causal language
+python scripts/check_refutation.py --refutation <slug>/refutation.json --output <slug>/check_report.json
+```
+
+The `refutation.json` is written by the analyst from DoWhy/CausalPy refutation outputs. See the
+[script docstring](scripts/check_refutation.py) for the JSON schema, the test categories
+(critical vs. marginal), and the language calibration rules.
 
 ## When things go wrong
 

--- a/causal-inference/references/refutation.md
+++ b/causal-inference/references/refutation.md
@@ -400,7 +400,13 @@ result = cp.InterruptedTimeSeries(
     formula="y ~ 1 + t",
     model=cp.pymc_models.LinearRegression(sample_kwargs={"random_seed": rng, "nuts_sampler": "nutpie"}),
 )
-result.plot()  # does the post-period effect persist, decay, or reverse?
+result.plot()  # actual vs counterfactual, with the campaign window shaded
+
+# CausalPy computes the persistence ratio directly = post-period effect / during-period effect:
+p = result.analyze_persistence(direction="two-sided")
+# persistence_ratio: ~1 = effect held, 0-1 = decayed, ~0 = vanished, negative = rebounded.
+# Guard: a ratio built on a near-zero during-period effect is unstable — check the
+# during-period effect is distinguishable from zero before interpreting the ratio.
 ```
 
 **This is a functional-form / specification check, not an identification refutation.** It asks whether your *assumed effect shape* (permanent step vs. temporary pulse) matches the data; it says nothing about confounding — which is what actually breaks ITS, so keep the placebo-time and concurrent-event checks for that. Note too that after `treatment_end_time` CausalPy reverts the counterfactual to the **extrapolated pre-treatment trend**, so any persistence/decay read-off inherits the assumption — stronger the longer the post-window — that the pre-period trend remains the valid counterfactual throughout. State it.

--- a/causal-inference/references/refutation.md
+++ b/causal-inference/references/refutation.md
@@ -122,6 +122,27 @@ When treatment is staggered (units adopt treatment at different times), the stan
 
 ## Synthetic Control refutation recipes
 
+### Donor support (positivity / convex hull)
+
+Check this *first*. A synthetic control weights donors with non-negative weights that sum to one, so the synthetic unit is a **convex combination** of donors: its pre-treatment vector lies in the donor **convex hull**, and SC cannot represent a treated unit outside that hull — it interpolates, never extrapolates. If the treated unit is more extreme than the donors can span, the fit is forced to the hull boundary and the post-treatment "gap" is partly an artifact of poor support, not a treatment effect.
+
+```python
+# Cheap PRE-SCREEN: is the treated unit inside the donor min–max band each period?
+pre = df[df["time"] < treatment_time]
+# SC assumes a single treated unit; this reports the fraction per treated unit.
+treated_pre = pre[pre["unit"].isin(treated_units)].pivot(index="time", columns="unit", values="outcome")
+donor_pre = pre[pre["unit"].isin(control_units)].pivot(index="time", columns="unit", values="outcome")
+
+lo, hi = donor_pre.min(axis=1), donor_pre.max(axis=1)
+outside = (treated_pre.lt(lo, axis=0) | treated_pre.gt(hi, axis=0)).mean()  # per treated unit
+print(outside.to_string())  # fraction of pre-periods outside the donor envelope
+
+# FAIL (outside > 0) is informative: the treated unit breaches the donor range → support problem.
+# PASS (outside ≈ 0) is NOT sufficient — see the caveat below.
+```
+
+**A FAIL is informative; a PASS is not.** The per-period min–max envelope is only a *necessary* condition for hull membership, checked marginally one period at a time, so it is a **loose, anti-conservative screen** — it under-detects support failures. A unit can stay inside the band at *every* period yet lie outside the *joint* convex hull: donors `(0, 10)` and `(10, 0)` bracket a treated `(0, 0)` in each period, yet no convex weighting reproduces it (every convex combination has the two coordinates summing to 10). For a rigorous check, test hull membership directly — solve the simplex-constrained fit `min ‖x_treated − W·x_donors‖` s.t. `w ≥ 0, Σw = 1` and confirm the residual is ≈ 0 (or an LP / `scipy.spatial` feasibility test) — and use the envelope only as a cheap pre-screen. If support genuinely fails: add donors that bracket the treated unit, restrict the pre-period to where support holds, or switch to a method that *models* the trend (e.g. a Bayesian structural time series) rather than reweighting donors. (This is **support / positivity** — distinct from, and looser than, literal convex-hull membership.)
+
 ### Leave-one-out donors
 
 Re-fit the synthetic control model removing each donor unit one at a time. If the post-treatment trajectory changes dramatically when any single donor is removed, the result is fragile and dependent on that one unit.
@@ -366,6 +387,25 @@ ITS is especially vulnerable to events that happened at the same time as the tre
 > **Ask the user:** "Did anything else change at or near the treatment time that could explain the observed trend change? Examples: a policy change elsewhere, a market shock, a shift in data collection practices, a simultaneous intervention on a related variable."
 
 If the user identifies a potential confound, either (a) control for it by adding it to the model, (b) collect data on a control unit that experienced the confound but not the treatment (converting ITS to DiD), or (c) downgrade the causal claim.
+
+### Effect persistence (temporary interventions)
+
+Not every intervention is a permanent level shift. If the treatment was temporary (a one-off campaign, a time-boxed policy, a transient shock), a model that assumes a permanent step mis-estimates the effect — it smears a short-lived bump across the whole post-period, or misreads a decaying effect as a sustained one. Pass the intervention's end so the counterfactual can revert to baseline, and inspect whether the post-treatment effect **persists or decays**.
+
+```python
+result = cp.InterruptedTimeSeries(
+    data=df,
+    treatment_time=treatment_time,
+    treatment_end_time=treatment_end_time,  # counterfactual reverts to the pre-trend after this
+    formula="y ~ 1 + t",
+    model=cp.pymc_models.LinearRegression(sample_kwargs={"random_seed": rng, "nuts_sampler": "nutpie"}),
+)
+result.plot()  # does the post-period effect persist, decay, or reverse?
+```
+
+**This is a functional-form / specification check, not an identification refutation.** It asks whether your *assumed effect shape* (permanent step vs. temporary pulse) matches the data; it says nothing about confounding — which is what actually breaks ITS, so keep the placebo-time and concurrent-event checks for that. Note too that after `treatment_end_time` CausalPy reverts the counterfactual to the **extrapolated pre-treatment trend**, so any persistence/decay read-off inherits the assumption — stronger the longer the post-window — that the pre-period trend remains the valid counterfactual throughout. State it.
+
+If the assumed shape matches the data (a sustained shift stays elevated; a temporary one returns toward baseline), the specification is adequate. If you assumed a permanent shift but the effect clearly decays, re-specify the dynamics and report the effect as transient — but observed decay is evidence against the effect's *permanence*, not against its *existence*.
 
 ---
 

--- a/causal-inference/references/reporting.md
+++ b/causal-inference/references/reporting.md
@@ -2,15 +2,229 @@
 
 ## Contents
 
-1. [Causal analysis report template](#causal-analysis-report-template)
-2. [Causal language guardrails](#causal-language-guardrails)
-3. [Decision-relevant HDIs](#decision-relevant-hdis)
-4. [Audience adaptation](#audience-adaptation)
-5. [Common reporting mistakes](#common-reporting-mistakes)
+1. [Canonical report artifact](#canonical-report-artifact)
+2. [Causal analysis report template (legacy / inline)](#causal-analysis-report-template)
+3. [Causal language guardrails](#causal-language-guardrails)
+4. [Decision-relevant HDIs](#decision-relevant-hdis)
+5. [Audience adaptation](#audience-adaptation)
+6. [Common reporting mistakes](#common-reporting-mistakes)
+
+---
+
+## Canonical report artifact
+
+Every causal analysis writes `report.md` inside a dedicated results folder. Static descriptions are verbatim — copy them as-is. `<placeholders>` are dynamic — fill them in from the actual run. Sections marked **[IF …]** are design-specific and should be included only when applicable.
+
+### Results folder naming
+
+Slug pattern: `<treatment>-on-<outcome>/`. Use lowercase-hyphenated, 1–4 words. For example: `policy-on-test-scores`, `exercise-on-bp`, `tariff-on-export-volume`. When iterating, append a version: `policy-on-test-scores-v2/`.
+
+```python
+import os
+
+results_dir = "<treatment>-on-<outcome>"  # e.g., "policy-on-test-scores"
+os.makedirs(results_dir, exist_ok=True)
+```
+
+### Output structure
+
+```
+<treatment>-on-<outcome>/
+├── inference_data.nc            # full InferenceData from estimation
+├── dag.png                      # rendered DAG (CausalModel.plot or graphviz)
+├── effect_posterior.png         # posterior of the causal effect
+├── forest.png                   # forest of all relevant parameters
+├── parallel_trends.png          # [IF DiD]
+├── pre_treatment_fit.png        # [IF SC]
+├── placebo_density.png          # [IF SC] distribution of placebo effects
+├── density_test.png             # [IF RDD] McCrary density
+├── bandwidth_sensitivity.png    # [IF RDD]
+├── autocorrelation.png          # [IF ITS]
+├── sensitivity_tipping.png      # unobserved confounder tipping point
+├── refutation.json              # structured refutation outcomes
+├── identification.json          # identified estimand + adjustment set
+├── effect_summary.csv           # effect estimates + HDIs at multiple widths
+└── report.md                    # this template, filled in
+```
+
+### Report template
+
+Copy this template verbatim into `<results-folder>/report.md` and fill in the `<placeholders>`. Keep static paragraphs as-is.
+
+````markdown
+# <Causal Question> — Causal Analysis Report
+
+## 1. Causal Question
+
+<One sentence: "What is the effect of <treatment> on <outcome> in <population>?" If you cannot write this sentence, you do not have a causal question yet — you have a dataset.>
+
+**Estimand:** <ATE / ATT / LATE / CATE — be specific, including the conditioning set if applicable.>
+
+## 2. DAG and Assumptions
+
+![Causal graph](dag.png)
+
+The directed acyclic graph encodes which variables are assumed to cause which others. Edges express direct causal effects assumed by the analyst. The *absence* of an edge between two variables is the most consequential assumption — it asserts there is no direct causal effect, even after conditioning. Identification of the causal effect depends entirely on this graph being correct.
+
+| Assumption | Testable? | Fragility | What if violated? |
+|------------|-----------|-----------|-------------------|
+| <e.g., No unobserved confounders> | <No / Partially / Yes> | <Robust / Moderate / Fragile> | <e.g., Effect biased in unknown direction> |
+
+<For each fragile assumption listed above, briefly state what evidence (if any) supports it. Untestable assumptions still need a defensible argument.>
+
+## 3. Identification Strategy
+
+<"We use <method (backdoor / frontdoor / DiD parallel trends / RDD continuity / IV exclusion+relevance / structural)> to identify the causal effect. This is valid because <justification, in 1–2 sentences>.">
+
+**Adjustment set / instrument / running variable:** <list the variables>
+
+**[IF NOT POINT-IDENTIFIED]** The effect is not point-identified under the available assumptions. We report bounds rather than a point estimate.
+
+## 4. Estimation
+
+**Design:** <DiD / Synthetic Control / RDD / ITS / IV / IPSW / Structural>
+
+**Model:** <likelihood, link, key priors — link to bayesian-workflow's diagnostics standards rather than restating them>
+
+**Convergence summary:** <one line — R-hat, ESS, divergences. Use the bayesian-workflow harness if available.>
+
+## 5. Results
+
+![Effect posterior](effect_posterior.png)
+
+The posterior distribution of the causal effect is the result. Point estimates and intervals are summaries of this posterior.
+
+| | Value |
+|---|---|
+| Posterior median | <value in domain units> |
+| 50% HDI | [<lo>, <hi>] |
+| 89% HDI | [<lo>, <hi>] |
+| 95% HDI | [<lo>, <hi>] |
+| P(effect > 0) | <prob> |
+| P(\|effect\| > <decision threshold>) | <prob> |
+
+**Interpretation.** <2–4 sentences in domain language. Translate the effect to natural frequencies for non-technical readers (e.g., "for every 100 people exposed, we estimate 8 more would <outcome>"). State whether the result depends on a particular HDI width.>
+
+## 6. Refutation
+
+The strength of causal language must match the strength of refutation results. We report every test, including failures.
+
+| Test | Outcome | Rating |
+|------|---------|--------|
+| <e.g., Placebo treatment time> | <result> | <PASS / MARGINAL / FAIL> |
+| <e.g., Random common cause (DoWhy)> | <result> | <PASS / MARGINAL / FAIL> |
+| <e.g., Data subset stability> | <result> | <PASS / MARGINAL / FAIL> |
+| Unobserved confounding sensitivity | tipping point ≈ <value> | <PASS / MARGINAL / FAIL> |
+
+**[IF DiD]**
+
+![Parallel trends](parallel_trends.png)
+
+Pre-treatment trends in treatment and control groups should be approximately parallel — same slope, possibly different levels. Visible divergence in the pre-period is direct evidence that parallel trends does not hold and the DiD estimate is biased.
+
+**Assessment:** <1–2 sentences — are pre-trends parallel? Any visible divergence?>
+
+**[IF SC]**
+
+![Pre-treatment fit](pre_treatment_fit.png) ![Placebo density](placebo_density.png)
+
+Synthetic control validity rests on close pre-treatment fit between treated unit and synthetic control. Placebo distributions show whether the post-treatment gap is unusually large compared to the same procedure applied to control units.
+
+**Assessment:** <1–2 sentences on fit quality and placebo distribution.>
+
+**[IF RDD]**
+
+![Density test](density_test.png) ![Bandwidth sensitivity](bandwidth_sensitivity.png)
+
+The McCrary density test checks for manipulation of the running variable around the threshold. Bandwidth sensitivity checks whether the estimate is stable across reasonable bandwidth choices.
+
+**Assessment:** <1–2 sentences — bunching at threshold? Estimate stability across bandwidths?>
+
+**[IF ITS]**
+
+![Autocorrelation](autocorrelation.png)
+
+ITS regressions on time-series data have correlated residuals. Spikes outside the confidence band on the ACF indicate residual autocorrelation that, if unmodeled, deflates standard errors.
+
+**Assessment:** <1–2 sentences — Durbin-Watson, residual autocorrelation, confounding events flagged by user.>
+
+### Sensitivity to Unobserved Confounding
+
+![Sensitivity tipping point](sensitivity_tipping.png)
+
+The tipping point is the unobserved confounder strength at which the estimated effect collapses to zero. Compare to the strongest *measured* confounder: a tipping point much larger than the strongest observed confounder is reassuring; a tipping point similar to or smaller than measured confounders means the result is fragile.
+
+**Tipping point:** <value>
+**Strongest observed confounder strength:** <value>
+**Ratio:** <tipping / observed>×
+
+**Assessment:** <one sentence — robust / marginal / fragile.>
+
+## 7. Causal Language Calibration
+
+Based on the refutation outcomes above, this analysis supports the following level of claim:
+
+> **<causal / suggestive / associational / descriptive>**
+
+<Use the harness output from `scripts/check_refutation.py`. Justify the chosen level in one sentence — which test result drove this calibration. If associational or descriptive, explicitly state that causal interpretation is not supported.>
+
+## 8. Limitations and Threats
+
+This section is **mandatory** and must be prominent — not buried in an appendix. Decision-makers must see it.
+
+Threats ranked by severity:
+
+1. **<biggest threat>** — <direction of bias if violated> <quantification (E-value, sensitivity tipping)> <what data or design would resolve it>
+2. **<next threat>** — <same structure>
+
+## 9. Plain-Language Conclusion
+
+> "We estimate <treatment> causes <outcome> to change by <effect> (<HDI>), assuming <key assumptions>. There is a <P>% probability the effect is positive. The main threat to this conclusion is <biggest weakness>. If that assumption is violated, the true effect could be <direction and magnitude of bias>."
+
+<If refutation downgraded the language to "associational" or "descriptive", rewrite the above sentence to match — do not use "causes" when you have not earned it.>
+
+## Suggested Next Steps
+
+<From `scripts/check_refutation.py` `suggest_next_steps()`. Tailor with problem-specific context.>
+
+1. <step>
+2. <step>
+
+## Appendix
+
+<Effect summary CSV, identification.json, refutation.json, code repository link, software versions.>
+````
+
+### Common "Suggested Next Steps" patterns
+
+The harness in `scripts/check_refutation.py` emits these automatically. Override only with problem-specific context.
+
+- All refutation passes, sensitivity tipping high → "Proceed with causal language. Communicate the effect with decision-relevant HDIs and the biggest threat in plain language."
+- One critical test fails (placebo non-zero, McCrary bunching, poor SC pre-fit) → "Downgrade to associational language. Investigate the failure: is it fixable (e.g., add donors, restrict bandwidth) or fundamental (manipulation, parallel trends violated)?"
+- Sensitivity tipping comparable to strongest observed confounder → "Result is fragile. Either collect more covariates, switch to a stronger design (find an instrument or discontinuity), or report explicitly as suggestive."
+- Multiple marginal failures, no critical fails → "Use suggestive language. Run alternative designs as cross-checks; if they agree, claim convergent evidence rather than identification from any single design."
+- Parallel trends violated in DiD → "Switch to synthetic control or trend-adjusted DiD. Quantify the bias the naive DiD introduced (often the most informative thing you can report)."
+- Poor SC pre-treatment fit → "Expand donor pool, add predictors, or switch to BSTS. Do not interpret the post-treatment gap until pre-fit is acceptable."
+
+### Refutation metric directions
+
+`check_refutation.py` selects the correct pass-direction from each canonical test name, so you usually do **not** set `metric` in `refutation.json` — just name the test. The non-obvious directions it handles for you:
+
+| Test(s) | What PASS means | Auto metric |
+|---------|-----------------|-------------|
+| `placebo_treatment_time`, `dowhy_placebo_treatment` | placebo effect brackets 0 | `effect` |
+| `parallel_trends_pretest`, `mccrary_density`, `autocorrelation`, `covariate_balance` | **high** p-value — fail to reject the *good* null | `pvalue_high_good` |
+| `sc_pre_treatment_fit` | low pre-fit RMSE ratio | `rmse_ratio` |
+| `iv_first_stage_strength` | high first-stage F | `strength` |
+| `random_common_cause`, `data_subset`, `leave_one_out_donors` | small shift in the estimate | `shift` |
+
+**The trap this avoids:** for parallel-trends and McCrary, a *low* p-value is bad — it rejects parallel pre-trends or signals running-variable manipulation. Labeling those with a generic `pvalue` metric (which treats low as good, for "fraction of placebos as extreme as treated" style scores) silently flips a FAIL into a PASS and lets the report claim a causal effect it has not earned. When unsure, omit `metric` and let the test name drive it.
 
 ---
 
 ## Causal analysis report template
+
+> The canonical artifact above is the source of truth. The inline structure below is kept for reference and for cases where a one-off prose report is more useful than a slug-folder artifact.
 
 Every causal analysis produces a report with this mandatory structure. Adapt sections as needed, but do not drop sections 1, 7, or 8 — they are non-negotiable.
 

--- a/causal-inference/scripts/check_refutation.py
+++ b/causal-inference/scripts/check_refutation.py
@@ -1,0 +1,589 @@
+"""
+Interpret causal refutation outcomes and calibrate causal language.
+
+Reads a structured refutation JSON (the analyst writes this from DoWhy /
+CausalPy results) and produces:
+
+- Per-test pass/marginal/fail ratings using house thresholds
+- A causal-language calibration: causal / suggestive / associational / descriptive
+- An ordered list of suggested next steps
+
+This is the causal-inference analog of bayesian-workflow's check_diagnostics.py
+and amortized-workflow's check_diagnostics.py. The script does not run
+refutations — it interprets results that the analyst has already produced.
+
+Input format (refutation.json):
+    {
+      "design": "DiD" | "SC" | "RDD" | "ITS" | "IV" | "IPSW" | "Structural",
+      "tests": {
+        "<test_name>": {
+          "result": <number or null>,         # e.g., placebo effect mean, p-value, RMSE ratio
+          "hdi": [<lo>, <hi>],                 # optional, when applicable
+          "passes_zero": true | false,         # for HDIs; null if not applicable
+          "metric": "<optional — see below>",  # omit to auto-select by test name
+          "notes": "<optional analyst note>"
+        }
+      },
+
+    The "metric" field is OPTIONAL. When omitted, the correct pass-direction is
+    chosen from the canonical test name via DEFAULT_METRIC_BY_TEST — this is the
+    safe default and avoids the direction-inversion footgun below. Supported:
+
+      "effect"           PASS when the HDI brackets zero (placebo/falsification
+                         effect should be null).
+      "shift"            PASS when |relative shift| is small (estimate barely
+                         moves under perturbation: random common cause, subset).
+      "rmse_ratio"       PASS when low (SC pre-treatment fit RMSE / effect).
+      "fraction"         PASS when low (e.g., fraction of placebos as extreme as
+                         treated, fraction of bandwidths that flip sign).
+      "pvalue"           PASS when LOW (< 0.10). For "badness" scores where a
+                         small value is good — NOT for ordinary GOF p-values.
+      "pvalue_high_good" PASS when HIGH (>= 0.10). For falsification tests where
+                         failing to reject the GOOD null is what you want:
+                         parallel-trends pre-test, McCrary density, residual
+                         autocorrelation, covariate balance.
+      "strength"         PASS when HIGH (>= 10). Instrument first-stage F.
+                         ("auc" is accepted as a back-compat alias.)
+
+    Direction trap: for parallel-trends and McCrary, a LOW p-value is BAD (it
+    rejects parallel pre-trends / signals manipulation). Labeling them "pvalue"
+    would invert the verdict. Prefer omitting "metric" so the test name drives it.
+      "sensitivity": {
+        "tipping_point": <number>,
+        "strongest_observed_confounder": <number>,
+        "notes": "<optional>"
+      }
+    }
+
+Usage:
+    python check_refutation.py --refutation refutation.json
+    python check_refutation.py --refutation refutation.json --output check_report.json
+"""
+
+import argparse
+import json
+import sys
+
+
+# House thresholds — internal reference levels. Use the qualitative labels
+# (PASS / MARGINAL / FAIL) in reports, not these raw numbers.
+
+# Critical tests: failure of any one is disqualifying for causal language.
+CRITICAL_TESTS = {
+    "placebo_treatment_time",
+    "dowhy_placebo_treatment",
+    "mccrary_density",
+    "sc_pre_treatment_fit",
+    "parallel_trends_pretest",
+    "iv_first_stage_strength",
+}
+
+# Marginal tests: failure warrants caveats but not full disqualification.
+MARGINAL_ONLY_TESTS = {
+    "bandwidth_sensitivity",
+    "data_subset",
+    "leave_one_out_donors",
+    "autocorrelation",
+    "covariate_balance",
+    "random_common_cause",
+}
+
+# Default metric per canonical test — picks the correct pass-direction so the
+# analyst never has to. An explicit "metric" in the test dict overrides this.
+# This is the primary guard against direction inversion (e.g., rating a
+# significant parallel-trends pre-test as PASS).
+DEFAULT_METRIC_BY_TEST = {
+    "placebo_treatment_time": "effect",          # placebo effect should bracket 0
+    "dowhy_placebo_treatment": "effect",
+    "random_common_cause": "shift",              # estimate should barely move
+    "data_subset": "shift",
+    "leave_one_out_donors": "shift",
+    "sc_pre_treatment_fit": "rmse_ratio",        # pre-RMSE / effect, lower better
+    "bandwidth_sensitivity": "fraction",         # fraction of bw sign-flips, lower better
+    "mccrary_density": "pvalue_high_good",       # high p = no manipulation
+    "parallel_trends_pretest": "pvalue_high_good",  # high p = parallel pre-trends
+    "autocorrelation": "pvalue_high_good",       # high p = no residual autocorrelation
+    "covariate_balance": "pvalue_high_good",     # high p = balanced
+    "iv_first_stage_strength": "strength",       # first-stage F, higher better
+}
+
+# Sensitivity ratio thresholds (tipping_point / strongest_observed_confounder)
+SENSITIVITY_ROBUST = 3.0  # tipping point ≥ 3× strongest observed → robust
+SENSITIVITY_MARGINAL = 1.5  # 1.5–3× → marginal
+
+
+def _rate_effect_test(test: dict) -> str:
+    """Tests whose 'PASS' means: effect is indistinguishable from zero
+    (placebo treatment, placebo time, placebo threshold, random common cause)."""
+    hdi = test.get("hdi")
+    passes_zero = test.get("passes_zero")
+    if passes_zero is True or (hdi and hdi[0] <= 0 <= hdi[1]):
+        return "PASS"
+    # HDI excludes zero — fail if even its nearest edge sits well away from zero
+    # (a clearly non-null placebo/falsification effect), else marginal.
+    result = test.get("result")
+    if result is None:
+        return "MARGINAL"
+    if hdi:
+        nearest_edge = min(abs(hdi[0]), abs(hdi[1]))
+        if nearest_edge > 0.3 * abs(result):
+            return "FAIL"
+        return "MARGINAL"
+    return "MARGINAL"
+
+
+def _rate_pvalue_test(test: dict) -> str:
+    """Tests reporting a p-value-analogue (e.g., SC placebo fraction).
+    Lower is better. PASS if < 0.10, MARGINAL if < 0.20, FAIL otherwise."""
+    p = test.get("result")
+    if p is None:
+        return "MARGINAL"
+    if p < 0.10:
+        return "PASS"
+    if p < 0.20:
+        return "MARGINAL"
+    return "FAIL"
+
+
+def _rate_rmse_ratio_test(test: dict) -> str:
+    """SC pre-treatment fit: ratio of pre-RMSE to post-treatment effect.
+    PASS if < 0.10, MARGINAL if < 0.30, FAIL otherwise."""
+    r = test.get("result")
+    if r is None:
+        return "MARGINAL"
+    if r < 0.10:
+        return "PASS"
+    if r < 0.30:
+        return "MARGINAL"
+    return "FAIL"
+
+
+def _rate_shift_test(test: dict) -> str:
+    """Tests reporting a shift in the estimate (random common cause, data subset).
+    The reported number is typically the relative shift |new - original| / |original|.
+    PASS if < 0.10, MARGINAL if < 0.25, FAIL otherwise."""
+    s = test.get("result")
+    if s is None:
+        return "MARGINAL"
+    if abs(s) < 0.10:
+        return "PASS"
+    if abs(s) < 0.25:
+        return "MARGINAL"
+    return "FAIL"
+
+
+def _rate_fraction_test(test: dict) -> str:
+    """Generic fraction-style metrics where lower is better.
+    e.g., fraction of placebos as extreme as treated (SC), or fraction of
+    bandwidth values where estimate flips sign (RDD)."""
+    return _rate_pvalue_test(test)
+
+
+def _rate_pvalue_high_good(test: dict) -> str:
+    """Falsification / goodness-of-fit p-values where FAILING to reject the
+    (good) null is the desired outcome: parallel-trends pre-test, McCrary
+    density, residual autocorrelation, covariate balance.
+
+    HIGH p = PASS. This is the opposite direction from _rate_pvalue_test, and
+    using the wrong one is exactly how a violated parallel-trends assumption
+    gets silently rated PASS."""
+    p = test.get("result")
+    if p is None:
+        return "MARGINAL"
+    if p >= 0.10:
+        return "PASS"
+    if p >= 0.05:
+        return "MARGINAL"
+    return "FAIL"
+
+
+def _rate_strength_test(test: dict) -> str:
+    """Instrument strength / first-stage F-statistic (higher is better).
+    F > 10 is the conventional 'not weak' threshold."""
+    v = test.get("result")
+    if v is None:
+        return "MARGINAL"
+    if v >= 10:
+        return "PASS"
+    if v >= 5:
+        return "MARGINAL"
+    return "FAIL"
+
+
+def _effective_metric(name: str, test: dict) -> str:
+    """Explicit 'metric' wins; otherwise auto-select by canonical test name."""
+    return test.get("metric") or DEFAULT_METRIC_BY_TEST.get(name, "effect")
+
+
+def _rate_test(name: str, test: dict) -> str:
+    """Dispatch on the effective metric (explicit, or auto-selected by name)."""
+    metric = _effective_metric(name, test)
+    if metric == "effect":
+        return _rate_effect_test(test)
+    if metric == "pvalue":
+        return _rate_pvalue_test(test)
+    if metric == "pvalue_high_good":
+        return _rate_pvalue_high_good(test)
+    if metric == "rmse_ratio":
+        return _rate_rmse_ratio_test(test)
+    if metric == "shift":
+        return _rate_shift_test(test)
+    if metric == "fraction":
+        return _rate_fraction_test(test)
+    if metric in ("strength", "auc"):  # "auc" kept as a back-compat alias
+        return _rate_strength_test(test)
+    return "MARGINAL"
+
+
+def _rate_sensitivity(sensitivity: dict | None) -> tuple[str, float | None]:
+    """Rate the unobserved confounding sensitivity tipping point.
+
+    Returns (rating, ratio). Ratio is tipping / strongest_observed.
+    """
+    if not sensitivity:
+        return "MARGINAL", None
+
+    tip = sensitivity.get("tipping_point")
+    obs = sensitivity.get("strongest_observed_confounder")
+
+    if tip is None:
+        return "MARGINAL", None
+    if obs is None or obs <= 0:
+        # No reference point — only the tipping point itself
+        if tip > 0.5:
+            return "PASS", None
+        if tip > 0.2:
+            return "MARGINAL", None
+        return "FAIL", None
+
+    ratio = tip / obs
+    if ratio >= SENSITIVITY_ROBUST:
+        return "PASS", ratio
+    if ratio >= SENSITIVITY_MARGINAL:
+        return "MARGINAL", ratio
+    return "FAIL", ratio
+
+
+def check_refutation(refutation: dict) -> dict:
+    """Interpret refutation outcomes into per-test ratings + summary.
+
+    Parameters
+    ----------
+    refutation : dict
+        Schema as documented in the module docstring.
+
+    Returns
+    -------
+    dict
+        Structured assessment with per-test ratings, sensitivity rating,
+        and a summary suitable for the report's pass/fail table.
+    """
+    report: dict = {
+        "design": refutation.get("design", "unknown"),
+        "tests": {},
+        "sensitivity": {},
+    }
+
+    for name, test in refutation.get("tests", {}).items():
+        rating = _rate_test(name, test)
+        is_critical = name in CRITICAL_TESTS
+        report["tests"][name] = {
+            "rating": rating,
+            "critical": is_critical,
+            # Record the metric actually used (auto-selected when omitted) so the
+            # report is transparent about how each verdict was reached.
+            "metric": _effective_metric(name, test),
+            "result": test.get("result"),
+            "notes": test.get("notes", ""),
+        }
+
+    sens_rating, sens_ratio = _rate_sensitivity(refutation.get("sensitivity"))
+    report["sensitivity"] = {
+        "rating": sens_rating,
+        "ratio": sens_ratio,
+        "tipping_point": (refutation.get("sensitivity") or {}).get("tipping_point"),
+        "strongest_observed": (refutation.get("sensitivity") or {}).get(
+            "strongest_observed_confounder"
+        ),
+    }
+
+    return report
+
+
+def calibrate_causal_language(report: dict) -> dict:
+    """Map the refutation report to one of:
+    causal / suggestive / associational / descriptive.
+
+    Returns a dict with the level, the driving test, and a justification.
+    """
+    tests = report.get("tests", {})
+    sens = report.get("sensitivity", {})
+
+    # Identify failures by tier
+    critical_fails = [n for n, t in tests.items() if t["critical"] and t["rating"] == "FAIL"]
+    critical_marginal = [
+        n for n, t in tests.items() if t["critical"] and t["rating"] == "MARGINAL"
+    ]
+    non_critical_fails = [
+        n for n, t in tests.items() if not t["critical"] and t["rating"] == "FAIL"
+    ]
+    non_critical_marginal = [
+        n for n, t in tests.items() if not t["critical"] and t["rating"] == "MARGINAL"
+    ]
+
+    sens_rating = sens.get("rating", "MARGINAL")
+
+    # ── Critical failure → associational ──────────────────────────────
+    if critical_fails:
+        return {
+            "level": "associational",
+            "driving_test": critical_fails[0],
+            "justification": (
+                f"A critical refutation test failed ({critical_fails[0]}). "
+                "Causal interpretation is not supported; report as associational."
+            ),
+        }
+
+    # ── Sensitivity FAIL → associational ──────────────────────────────
+    if sens_rating == "FAIL":
+        return {
+            "level": "associational",
+            "driving_test": "sensitivity_to_unobserved_confounding",
+            "justification": (
+                "Tipping point for unobserved confounding is comparable to or "
+                "smaller than the strongest observed confounder. Effect is "
+                "fragile; causal interpretation is not supported."
+            ),
+        }
+
+    # ── Critical marginal OR multiple non-critical fails → suggestive ─
+    if critical_marginal or len(non_critical_fails) >= 2:
+        driver = (critical_marginal or non_critical_fails)[0]
+        return {
+            "level": "suggestive",
+            "driving_test": driver,
+            "justification": (
+                f"Some refutation tests are marginal or failing ({driver} and "
+                f"others). Use hedged language: 'evidence is suggestive of a "
+                "causal effect, but cannot be considered definitive.'"
+            ),
+        }
+
+    # ── Sensitivity MARGINAL → suggestive ─────────────────────────────
+    if sens_rating == "MARGINAL":
+        ratio = sens.get("ratio")
+        ratio_text = f" (tipping point ≈ {ratio:.1f}× strongest observed)" if ratio else ""
+        return {
+            "level": "suggestive",
+            "driving_test": "sensitivity_to_unobserved_confounding",
+            "justification": (
+                f"Sensitivity to unobserved confounding is marginal{ratio_text}. "
+                "Use hedged causal language."
+            ),
+        }
+
+    # ── Many non-critical marginal → suggestive ───────────────────────
+    if len(non_critical_marginal) >= 2:
+        return {
+            "level": "suggestive",
+            "driving_test": non_critical_marginal[0],
+            "justification": (
+                f"Multiple non-critical tests are marginal ({', '.join(non_critical_marginal[:2])}). "
+                "Use hedged causal language."
+            ),
+        }
+
+    # ── Otherwise: causal ─────────────────────────────────────────────
+    return {
+        "level": "causal",
+        "driving_test": None,
+        "justification": (
+            "All critical refutation tests pass and sensitivity to unobserved "
+            "confounding is robust. Causal language is supported."
+        ),
+    }
+
+
+def suggest_next_steps(report: dict, language: dict) -> list[str]:
+    """Return an ordered, actionable list of next steps based on the
+    refutation outcomes and the calibrated causal language."""
+    steps: list[str] = []
+    tests = report.get("tests", {})
+    sens = report.get("sensitivity", {})
+    design = report.get("design", "unknown")
+
+    # ── Critical failures (highest priority) ──────────────────────────
+    for name, t in tests.items():
+        if not t["critical"] or t["rating"] != "FAIL":
+            continue
+
+        if name == "placebo_treatment_time":
+            steps.append(
+                "Placebo treatment time produces a non-zero effect — parallel "
+                "trends or pre-treatment dynamics are likely violated. Inspect "
+                "the pre-period plot, consider unit-specific time trends, or "
+                "switch to synthetic control for heterogeneous pre-trends."
+            )
+        elif name == "mccrary_density":
+            steps.append(
+                "McCrary density test shows bunching at the threshold — units "
+                "are manipulating their position. The RDD design is invalid for "
+                "this threshold; do not interpret the discontinuity causally. "
+                "Consider a fuzzy RDD restricted to a wide bandwidth or a "
+                "different identification strategy."
+            )
+        elif name == "sc_pre_treatment_fit":
+            steps.append(
+                "Pre-treatment fit of synthetic control is poor — the synthetic "
+                "is not a credible counterfactual. Expand the donor pool, add "
+                "predictors to the formula, or switch to a Bayesian structural "
+                "time series model."
+            )
+        elif name == "parallel_trends_pretest":
+            steps.append(
+                "Pre-treatment trends are not parallel — the DiD parallel trends "
+                "assumption is not supported by the data. Switch to synthetic "
+                "control, trend-adjusted DiD, or explicitly bound the bias."
+            )
+        elif name == "dowhy_placebo_treatment":
+            steps.append(
+                "DoWhy placebo treatment refuter does not drive effect to zero — "
+                "the model is fitting noise. Re-examine the DAG and the "
+                "adjustment set; suspect residual confounding."
+            )
+        elif name == "iv_first_stage_strength":
+            steps.append(
+                "IV first-stage F-statistic is too weak — the instrument is "
+                "weak and IV estimates are biased and high-variance. Find a "
+                "stronger instrument or switch designs."
+            )
+        else:
+            steps.append(
+                f"Critical test {name} failed — investigate and either fix the "
+                "design or downgrade the language to associational."
+            )
+
+    # ── Sensitivity ───────────────────────────────────────────────────
+    if sens.get("rating") == "FAIL":
+        ratio = sens.get("ratio")
+        ratio_text = f" (tipping point ≈ {ratio:.1f}× strongest observed)" if ratio else ""
+        steps.append(
+            "Sensitivity to unobserved confounding is fragile" + ratio_text
+            + " — collect more covariates, switch to a quasi-experimental design "
+            "(find an instrument or discontinuity), or report explicitly as "
+            "associational."
+        )
+    elif sens.get("rating") == "MARGINAL":
+        steps.append(
+            "Sensitivity to unobserved confounding is marginal — quantify the "
+            "minimum confounder strength needed to overturn the result and "
+            "compare to plausible unmeasured variables (see refutation.md). "
+            "Use hedged language in the report."
+        )
+
+    # ── Critical marginal ─────────────────────────────────────────────
+    for name, t in tests.items():
+        if not t["critical"] or t["rating"] != "MARGINAL":
+            continue
+        steps.append(
+            f"Critical test {name} is marginal — strengthen the analysis "
+            "(more data, refined design, alternative estimator) or downgrade "
+            "language to 'suggestive'."
+        )
+
+    # ── Non-critical failures ─────────────────────────────────────────
+    nc_fails = [n for n, t in tests.items() if not t["critical"] and t["rating"] == "FAIL"]
+    if nc_fails:
+        steps.append(
+            f"Non-critical failures: {', '.join(nc_fails)}. Each warrants a "
+            "short paragraph in the limitations section explaining the failure "
+            "and what it implies for the conclusion."
+        )
+
+    # ── Design-specific reminders when no fails ───────────────────────
+    if not steps:
+        steps.append(
+            f"All refutation tests pass for the {design} design. Communicate "
+            "the effect with decision-relevant HDIs (50% / 89% / 95%) and the "
+            "biggest remaining threat in plain language. Run an alternative "
+            "design as a cross-check if feasible."
+        )
+
+    # ── Always: language calibration reminder ─────────────────────────
+    level = language.get("level")
+    if level in ("suggestive", "associational", "descriptive"):
+        steps.append(
+            f"Calibrated causal language is '{level}' — rewrite the conclusion "
+            "and abstract to match. Replace 'causes' with the appropriate "
+            "softer phrasing (see causal language guardrails in reporting.md)."
+        )
+
+    return steps
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Interpret causal refutation outcomes and calibrate causal language"
+    )
+    parser.add_argument(
+        "--refutation",
+        required=True,
+        help="Path to refutation.json (schema in module docstring)",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Path to save full JSON report (default: print to stdout)",
+    )
+    args = parser.parse_args()
+
+    try:
+        with open(args.refutation) as f:
+            refutation = json.load(f)
+    except FileNotFoundError:
+        print(json.dumps({"error": f"File not found: {args.refutation}"}))
+        sys.exit(1)
+    except json.JSONDecodeError as e:
+        print(json.dumps({"error": f"Could not parse {args.refutation}: {e}"}))
+        sys.exit(1)
+
+    report = check_refutation(refutation)
+    language = calibrate_causal_language(report)
+    next_steps = suggest_next_steps(report, language)
+
+    print("=== Refutation Ratings ===")
+    for name, t in report["tests"].items():
+        crit = "[CRITICAL]" if t["critical"] else ""
+        print(f"  {name}: {t['rating']} {crit}")
+    sens = report["sensitivity"]
+    if sens.get("rating"):
+        ratio = sens.get("ratio")
+        ratio_text = f" (ratio={ratio:.2f})" if ratio else ""
+        print(f"  sensitivity: {sens['rating']}{ratio_text}")
+    print("==========================\n")
+
+    print("=== Calibrated Causal Language ===")
+    print(f"  Level: {language['level'].upper()}")
+    print(f"  Driver: {language['driving_test']}")
+    print(f"  Why: {language['justification']}")
+    print("=================================\n")
+
+    print("=== Suggested Next Steps ===")
+    for i, s in enumerate(next_steps, 1):
+        print(f"  {i}. {s}")
+    print("============================\n")
+
+    full = {
+        "ratings": report,
+        "language": language,
+        "next_steps": next_steps,
+    }
+    output = json.dumps(full, indent=2)
+    if args.output:
+        with open(args.output, "w") as f:
+            f.write(output)
+        print(f"Report saved to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/evals/bayesian-workflow/iteration-1/discrete-latent-marginalization/eval_metadata.json
+++ b/evals/bayesian-workflow/iteration-1/discrete-latent-marginalization/eval_metadata.json
@@ -1,0 +1,14 @@
+{
+  "eval_id": 8,
+  "eval_name": "discrete-latent-marginalization",
+  "prompt": "I'm modeling reaction times that I think come from two latent cognitive states (a fast state and a slow state), with a per-trial indicator for which state generated each observation. My first attempt put a Bernoulli latent on every trial and used pm.math.switch to pick the rate, then sampled with nutpie — but sampling is a mess and barely moves. How should I structure this model in PyMC?",
+  "assertions": [
+    "Identifies that NUTS / nutpie cannot sample discrete (Bernoulli/Categorical) latent variables",
+    "Recommends marginalizing the discrete latent analytically — e.g. a mixture likelihood (pm.Mixture / pm.NormalMixture) or pmx.marginalize — instead of sampling per-trial indicators",
+    "Explains that a soft/relaxed plug-in (using E[z], a softmax, or a continuous relaxation in place of the discrete draw) is not the correct marginal and is mathematically wrong",
+    "Notes the mixture needs an identification/ordering constraint (e.g. an ordered transform on the component means) to avoid label-switching",
+    "Provides concrete PyMC code using a marginalized mixture rather than discrete indicators",
+    "Does not present sampling the discrete indicators directly with nutpie as the recommended solution",
+    "Recommends re-checking convergence (R-hat, ESS, divergences) after the refactor"
+  ]
+}

--- a/evals/benchmark-portable-reporting-harness.md
+++ b/evals/benchmark-portable-reporting-harness.md
@@ -1,0 +1,35 @@
+# Benchmark — portable-reporting-harness-v1 (stage 1)
+
+Targeted benchmark for the branch's new + changed content. Method: `with_skill` runs invoke the
+relevant skill via the Skill tool and follow it; `without_skill` runs answer from base knowledge with
+no skill; both are graded against each scenario's `eval_metadata.json` assertions (assertions withheld
+from the answering agents). Run on the `baygent` env (PyMC 5.28 / CausalPy 0.8.0).
+
+## New scenarios — coverage for this branch's guidance
+
+| Scenario | with_skill | without_skill | lift | note |
+|----------|-----------|---------------|------|------|
+| discrete-latent-marginalization (bayesian) | 7/7 | 6/7 | +1 | base missed the soft-plug-in-is-wrong warning |
+| its-effect-persistence (causal) | 8/8 | 7/8 | +1 | base hand-rolled a 2-changepoint regression; missed CausalPy `treatment_end_time` / `analyze_persistence` |
+| mbias-adjustment-set (causal) | 7/7 | 7/7 | 0 | base handled M-bias unaided |
+
+Lift is modest: base models are strong on well-known theory (M-bias, mixtures). These scenarios earn
+their place as **regression guards** (they lock in the corrected guidance — notably the M-bias /
+pre-treatment-not-sufficient rule) and coverage for the specific tooling idioms, not as lift drivers.
+
+## Changed scenarios — regression check (with_skill)
+
+| Scenario | score | new content present? |
+|----------|-------|----------------------|
+| troubleshooting-divergences (bayesian) | 7/8 | ✓ sampling-failure escalation ladder (lone miss: didn't say "multimodality" explicitly — single-run variance, not a content regression) |
+| synthetic-control-poor-donors (causal) | 10/10 | ✓ donor-support hull pre-screen, with the "FAIL informative, PASS not sufficient" framing |
+| observational-dag-confounders (causal) | 11/11 | ✓ BMI-as-mediator + pre-treatment-not-sufficient reasoning |
+
+**No regressions** — the edits improved the changed scenarios rather than breaking them.
+
+## Verdict
+
+Merge gate (with_skill correctness + no regression on touched scenarios) is met: 22/22 on new
+scenarios, 28/29 on changed. The full remaining-scenario sweep (untouched scenarios + all iterations)
+is low marginal value for this branch — those scenarios exercise guidance this branch did not change —
+and is best run via the usual full-suite harness if a complete record is wanted.

--- a/evals/causal-inference/iteration-1/its-effect-persistence/eval_metadata.json
+++ b/evals/causal-inference/iteration-1/its-effect-persistence/eval_metadata.json
@@ -1,0 +1,15 @@
+{
+  "eval_id": 7,
+  "eval_name": "its-effect-persistence",
+  "prompt": "A city ran a 3-month anti-speeding ad campaign (January to March 2023) and I have weekly average vehicle speeds from 2021 through 2024. There is no comparable control city. I want to estimate the campaign's effect with an interrupted time series. How should I set it up, and how do I tell whether the effect actually lasted?",
+  "assertions": [
+    "Identifies this as an Interrupted Time Series (ITS) design",
+    "Recognizes the intervention is temporary (a fixed-window campaign), not a permanent level shift",
+    "Recommends passing the intervention end (treatment_end_time in CausalPy's InterruptedTimeSeries) so the counterfactual reverts after the campaign window",
+    "Inspects whether the post-treatment effect persists or decays rather than assuming a permanent shift",
+    "Notes the persistence/decay read-off depends on the pre-treatment trend remaining a valid counterfactual (an extrapolation assumption that strengthens the longer the post-window)",
+    "Frames the persistence question as a specification / functional-form check, distinct from confounding threats",
+    "Still addresses ITS confounding threats (concurrent events at the intervention time, residual autocorrelation)",
+    "Reports the effect with uncertainty and hedges causal language appropriately given there is no control group"
+  ]
+}

--- a/evals/causal-inference/iteration-1/mbias-adjustment-set/eval_metadata.json
+++ b/evals/causal-inference/iteration-1/mbias-adjustment-set/eval_metadata.json
@@ -1,0 +1,14 @@
+{
+  "eval_id": 8,
+  "eval_name": "mbias-adjustment-set",
+  "prompt": "I'm estimating the effect of a job-training program on later earnings from observational data. I have a variable, 'recruiter rating', recorded before enrollment that is correlated with both who enrolls and later earnings, so I planned to control for it. I also have pre-treatment education and age. Should I just adjust for everything that was measured before treatment?",
+  "assertions": [
+    "States that adjusting for everything pre-treatment is NOT automatically safe",
+    "Explains that pre-treatment timing is necessary but not sufficient for a valid adjustment set",
+    "Identifies the M-bias / collider risk: conditioning on a pre-treatment collider can induce bias that was not there",
+    "Reasons about the causal structure of 'recruiter rating' (what causes it, what it causes) rather than adjusting reflexively",
+    "States that the DAG / back-door criterion — not timing — determines the adjustment set",
+    "Recommends building or confirming a DAG before choosing the adjustment set",
+    "Does not blanket-recommend controlling for all pre-treatment covariates"
+  ]
+}

--- a/evals/smoke/test_reporting_harness.py
+++ b/evals/smoke/test_reporting_harness.py
@@ -1,0 +1,190 @@
+"""
+Smoke test for the portable reporting harness.
+
+Runs the bayesian-workflow diagnostics pipeline end-to-end on a tiny model and
+exercises the causal-inference refutation harness on fixtures. This is an
+INTEGRATION test: it catches contract breaks between scripts that no
+single-script unit test would surface.
+
+Regression guards (each maps to a real bug this test was written to lock down):
+
+  1. diagnose_model.py must emit JSON-serializable output — no numpy int64 or
+     xarray Dataset leaking into json.dumps. (Was: `TypeError: Object of type
+     int64 is not JSON serializable`, which killed step 1 of the pipeline.)
+  2. check_diagnostics.py must produce real, named next steps on the
+     arviz_stats.diagnose path — not the placeholder string
+     "see diagnose_model.py output for details".
+  3. check_refutation.py must NOT rate a *significant* parallel-trends pre-test
+     as PASS, and must not award "causal" language when it fails. (Was: the
+     generic p-value rater treated low p as good, inverting the verdict.)
+
+Run:
+    conda run -n baygent python evals/smoke/test_reporting_harness.py
+Exits 0 on success, 1 on any failed assertion.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+BAYES_SCRIPTS = REPO / "bayesian-workflow" / "scripts"
+CAUSAL_SCRIPTS = REPO / "causal-inference" / "scripts"
+
+FAILURES: list[str] = []
+
+
+def check(cond: bool, msg: str) -> None:
+    print(f"  [{'PASS' if cond else 'FAIL'}] {msg}")
+    if not cond:
+        FAILURES.append(msg)
+
+
+def run(cmd: list) -> tuple[int, str, str]:
+    """Run a script under the current interpreter; force a headless MPL backend."""
+    env = {**os.environ, "MPLBACKEND": "Agg"}
+    proc = subprocess.run(
+        [sys.executable, *map(str, cmd)], capture_output=True, text=True, env=env
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def load_or_fail(path: Path, label: str):
+    if not path.exists():
+        check(False, f"{label} written")
+        return None
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError as e:
+        check(False, f"{label} is valid JSON ({e})")
+        return None
+
+
+def build_idata(path: Path) -> None:
+    import numpy as np
+    import pymc as pm
+
+    rng = np.random.default_rng(sum(map(ord, "smoke-test")))
+    y = rng.normal(3.0, 1.0, size=80)
+    with pm.Model():
+        mu = pm.Normal("mu", 0, 5)
+        sigma = pm.HalfNormal("sigma", 5)
+        pm.Normal("obs", mu, sigma, observed=y)
+        idata = pm.sample(
+            400, tune=400, chains=2, progressbar=False,
+            idata_kwargs={"log_likelihood": True}, random_seed=42,
+        )
+        pm.sample_posterior_predictive(
+            idata, extend_inferencedata=True, progressbar=False
+        )
+    idata.to_netcdf(str(path))
+
+
+def test_bayesian_pipeline(workdir: Path) -> None:
+    print("\n== bayesian-workflow diagnostics pipeline ==")
+    idata_path = workdir / "inference_data.nc"
+    build_idata(idata_path)
+
+    # Step 1 — diagnose (regression guard #1: must not crash on json.dumps)
+    diag_json = workdir / "diagnostics.json"
+    rc, _, err = run([BAYES_SCRIPTS / "diagnose_model.py",
+                      "--idata", idata_path, "--output", diag_json])
+    check(rc == 0, f"diagnose_model.py exits 0 (rc={rc}); stderr: {err.strip()[-200:]}")
+    d = load_or_fail(diag_json, "diagnostics.json")
+    if d:
+        conv = d.get("convergence", {})
+        check("all_ok" in conv, "diagnostics.json has convergence.all_ok")
+        check("rhat" in conv and "problematic_params" in conv["rhat"],
+              "convergence carries the unified rhat schema")
+        check("diagnostics" not in conv,
+              "raw (non-serializable) diagnose() blob not embedded")
+
+    # Step 2 — calibration
+    cal_json = workdir / "calibration.json"
+    rc, _, err = run([BAYES_SCRIPTS / "calibration_check.py",
+                      "--idata", idata_path, "--output", cal_json,
+                      "--save-plots", "--plot-dir", workdir])
+    check(rc == 0, f"calibration_check.py exits 0 (rc={rc}); stderr: {err.strip()[-200:]}")
+    check((workdir / "pit_ecdf.png").exists(),
+          "pit_ecdf.png saved with the name the report template references")
+
+    # Step 3 — interpret (regression guard #2: no placeholder in next steps)
+    check_json = workdir / "check_report.json"
+    rc, _, err = run([BAYES_SCRIPTS / "check_diagnostics.py",
+                      "--diagnostics", diag_json, "--calibration", cal_json,
+                      "--output", check_json])
+    check(rc == 0, f"check_diagnostics.py exits 0 (rc={rc}); stderr: {err.strip()[-200:]}")
+    r = load_or_fail(check_json, "check_report.json")
+    if r:
+        check(bool(r.get("next_steps")), "check_report has a non-empty next_steps list")
+        check("see diagnose_model.py output for details" not in json.dumps(r),
+              "no placeholder parameter name leaks into the report")
+        check("convergence" in r.get("summary", {}),
+              "report has a convergence Assessment line")
+
+
+def test_refutation_direction(workdir: Path) -> None:
+    print("\n== causal-inference refutation harness ==")
+    script = CAUSAL_SCRIPTS / "check_refutation.py"
+
+    # Fixture A — parallel-trends pre-test is SIGNIFICANTLY violated (low p).
+    # Regression guard #3: must rate FAIL and must not award "causal".
+    bad = {
+        "design": "DiD",
+        "tests": {"parallel_trends_pretest": {"result": 0.01, "notes": "pre-trends differ"}},
+        "sensitivity": {"tipping_point": 0.4, "strongest_observed_confounder": 0.1},
+    }
+    p = workdir / "refutation_bad.json"
+    p.write_text(json.dumps(bad))
+    out = workdir / "check_bad.json"
+    rc, _, err = run([script, "--refutation", p, "--output", out])
+    check(rc == 0, f"check_refutation.py exits 0 on violated-trends fixture (rc={rc})")
+    r = load_or_fail(out, "check_bad.json")
+    if r:
+        rating = r["ratings"]["tests"]["parallel_trends_pretest"]["rating"]
+        check(rating == "FAIL", f"significant parallel-trends pre-test rated FAIL (got {rating})")
+        check(r["language"]["level"] != "causal",
+              f"language is not 'causal' when parallel trends fails (got {r['language']['level']})")
+
+    # Fixture B — clean refutation: causal language is earned.
+    good = {
+        "design": "DiD",
+        "tests": {
+            "parallel_trends_pretest": {"result": 0.85},
+            "placebo_treatment_time": {"hdi": [-0.2, 0.3], "result": 0.05, "passes_zero": True},
+        },
+        "sensitivity": {"tipping_point": 0.9, "strongest_observed_confounder": 0.1},
+    }
+    p = workdir / "refutation_good.json"
+    p.write_text(json.dumps(good))
+    out = workdir / "check_good.json"
+    rc, _, err = run([script, "--refutation", p, "--output", out])
+    check(rc == 0, f"check_refutation.py exits 0 on clean fixture (rc={rc})")
+    r = load_or_fail(out, "check_good.json")
+    if r:
+        rating = r["ratings"]["tests"]["parallel_trends_pretest"]["rating"]
+        check(rating == "PASS", f"high-p parallel-trends pre-test rated PASS (got {rating})")
+        check(r["language"]["level"] == "causal",
+              f"clean refutation earns 'causal' (got {r['language']['level']})")
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        workdir = Path(td)
+        test_bayesian_pipeline(workdir)
+        test_refutation_direction(workdir)
+
+    print("\n" + "=" * 56)
+    if FAILURES:
+        print(f"SMOKE TEST FAILED — {len(FAILURES)} assertion(s):")
+        for f in FAILURES:
+            print(f"  - {f}")
+        sys.exit(1)
+    print("SMOKE TEST PASSED — reporting harness runs end-to-end.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

A portable reporting harness for the **bayesian-workflow** and **causal-inference** skills, similar to what we already have for the amortized-workflow skill, plus a batch of generalizable guidance improvements, a tooling smoke test, and new eval coverage.

## bayesian-workflow → v1.4
- Canonical `<slug>/report.md` artifact + `check_diagnostics.py` interpreting harness (qualitative ratings + ordered next steps from the raw diagnostics JSON).
- Fixes: `diagnose_model.py` JSON serialization (numpy `int64`) + a clean unified convergence schema; `calibration_check.py` `ci_prob` → `envelope_prob` for arviz_plots 1.0.
- New guidance: NUTS **sampling-failure escalation ladder** (`diagnostics.md`); **discrete-latent marginalization** + disjoint-partition gotchas (`SKILL.md`); **interval-width principle** -- no width is magic, choose by decision context (`reporting.md`).

## causal-inference → v1.2
- Canonical `<treatment>-on-<outcome>/report.md` artifact + `check_refutation.py` calibrated causal-language harness (causal / suggestive / associational / descriptive). Fixed a **metric-direction inversion** (parallel-trends / McCrary: a high p-value is the good outcome).
- New guidance: **DAG-licensed adjustment rule** -- pre-treatment timing is necessary, *not sufficient* (M-bias); 5-step **design-intake checklist** with estimand/design reconciliation; synthetic-control **donor-support** (positivity / convex-hull) check; **ITS effect-persistence** check via CausalPy `analyze_persistence()`.

## Repo / tooling
- `evals/smoke/test_reporting_harness.py` -- end-to-end integration test guarding JSON serializability, the diagnose --> check schema contract, and refutation metric direction.
- `CLAUDE.md`: version bumps + skill-authoring heuristics.

## Evals
- 3 new scenarios closing coverage gaps: `discrete-latent-marginalization`, `its-effect-persistence`, `mbias-adjustment-set`.
- Stage-1 benchmark (`evals/benchmark-portable-reporting-harness.md`): **22/22** with_skill on new scenarios; **28/29** with_skill on changed scenarios (**no regressions**). Lift vs base is honestly small on these topics -- their value is regression-protection + tooling idioms.

## Verification
- Smoke test green on the `baygent` env (PyMC 5.28 / CausalPy 0.8.0).
- All new CausalPy / ArviZ APIs verified against the installed versions before inclusion (no reasoning by analogy).
